### PR TITLE
fix color assignment of pie and doughnut charts

### DIFF
--- a/docs/2_5_pie-doughnut-charts.fsx
+++ b/docs/2_5_pie-doughnut-charts.fsx
@@ -27,9 +27,8 @@ let labels = ["Residential"; "Non-Residential"; "Utility"]
 
 (**
 
-A pie or a doughnut chart can be created using the `Chart.Pie` and `Chart.Doughnut` functions.
-When creating pie or doughnut charts, it is usually desirable to provide both labels and 
-values.
+A pie, doughnut, or sunburst chart can be created using the `Chart.Pie`, `Chart.Doughnut`, and `Chart.Sunburst` functions.
+When creating pie charts, it is usually desirable to provide both labels and values.
 
 *)
 
@@ -60,4 +59,21 @@ doughnut1
 
 (***hide***)
 doughnut1 |> GenericChart.toChartHTML
+(***include-it-raw***)
+
+let sunburst1 =
+    Chart.Sunburst(
+        ["A";"B";"C";"D";"E"],
+        ["";"";"B";"B";""],
+        Values=[5.;0.;3.;2.;3.],
+        Text=["At";"Bt";"Ct";"Dt";"Et"]
+    )
+
+(*** condition: ipynb ***)
+#if IPYNB
+sunburst1
+#endif // IPYNB
+
+(***hide***)
+sunburst1 |> GenericChart.toChartHTML
 (***include-it-raw***)

--- a/src/Plotly.NET/Chart.fs
+++ b/src/Plotly.NET/Chart.fs
@@ -1269,7 +1269,7 @@ type Chart =
             [<Optional;DefaultParameterValue(null)>]  ?Labels,
             [<Optional;DefaultParameterValue(null)>]  ?Name,
             [<Optional;DefaultParameterValue(null)>]  ?Showlegend,
-            [<Optional;DefaultParameterValue(null)>]  ?Color,
+            [<Optional;DefaultParameterValue(null)>]  ?Colors,
             [<Optional;DefaultParameterValue(null)>]  ?TextPosition,
             [<Optional;DefaultParameterValue(null)>]  ?TextFont,
             [<Optional;DefaultParameterValue(null)>]  ?Hoverinfo,
@@ -1277,7 +1277,7 @@ type Chart =
             [<Optional;DefaultParameterValue(null)>]  ?Opacity) =         
         Trace.initPie (TraceStyle.Pie(Values=values,?Labels=Labels,?Textinfo=Textinfo))
         |> TraceStyle.TraceInfo(?Name=Name,?Showlegend=Showlegend,?Opacity=Opacity,?Hoverinfo=Hoverinfo)        
-        |> TraceStyle.Marker(?Color=Color)
+        |> TraceStyle.Marker(?Colors=Colors)
         |> TraceStyle.TextLabel(?Text=Labels,?Textposition=TextPosition,?Textfont=TextFont)
         |> GenericChart.ofTraceObject 
 
@@ -1286,14 +1286,14 @@ type Chart =
     static member Pie(data:seq<#IConvertible*#IConvertible>,
             [<Optional;DefaultParameterValue(null)>]  ?Name,
             [<Optional;DefaultParameterValue(null)>]  ?Showlegend,
-            [<Optional;DefaultParameterValue(null)>]  ?Color,
+            [<Optional;DefaultParameterValue(null)>]  ?Colors,
             [<Optional;DefaultParameterValue(null)>]  ?TextPosition,
             [<Optional;DefaultParameterValue(null)>]  ?TextFont,
             [<Optional;DefaultParameterValue(null)>]  ?Hoverinfo,
             [<Optional;DefaultParameterValue(null)>]  ?Textinfo,
             [<Optional;DefaultParameterValue(null)>]  ?Opacity) =         
         let values,labels = Seq.unzip data 
-        Chart.Pie(values,Labels=labels,?Name=Name,?Showlegend=Showlegend,?Color=Color,?TextPosition=TextPosition,?TextFont=TextFont,?Hoverinfo=Hoverinfo,?Textinfo=Textinfo,?Opacity=Opacity)
+        Chart.Pie(values,Labels=labels,?Name=Name,?Showlegend=Showlegend,?Colors=Colors,?TextPosition=TextPosition,?TextFont=TextFont,?Hoverinfo=Hoverinfo,?Textinfo=Textinfo,?Opacity=Opacity)
 
 
     /// Shows how proportions of data, shown as pie-shaped pieces, contribute to the data as a whole.
@@ -1301,7 +1301,7 @@ type Chart =
             [<Optional;DefaultParameterValue(null)>]  ?Labels,
             [<Optional;DefaultParameterValue(null)>]  ?Name,
             [<Optional;DefaultParameterValue(null)>]  ?Showlegend,
-            [<Optional;DefaultParameterValue(null)>]  ?Color,
+            [<Optional;DefaultParameterValue(null)>]  ?Colors,
             [<Optional;DefaultParameterValue(null)>]  ?Hole,
             [<Optional;DefaultParameterValue(null)>]  ?TextPosition,
             [<Optional;DefaultParameterValue(null)>]  ?TextFont,
@@ -1311,7 +1311,7 @@ type Chart =
         let hole' = if Hole.IsSome then Hole.Value else 0.4
         Trace.initPie (TraceStyle.Pie(Values=values,?Labels=Labels,?Textinfo=Textinfo,Hole=hole'))
         |> TraceStyle.TraceInfo(?Name=Name,?Showlegend=Showlegend,?Opacity=Opacity,?Hoverinfo=Hoverinfo)        
-        |> TraceStyle.Marker(?Color=Color)
+        |> TraceStyle.Marker(?Colors=Colors)
         |> TraceStyle.TextLabel(?Text=Labels,?Textposition=TextPosition,?Textfont=TextFont)
         |> GenericChart.ofTraceObject 
 
@@ -1320,7 +1320,7 @@ type Chart =
     static member Doughnut(data:seq<#IConvertible*#IConvertible>,
             [<Optional;DefaultParameterValue(null)>]  ?Name,
             [<Optional;DefaultParameterValue(null)>]  ?Showlegend,
-            [<Optional;DefaultParameterValue(null)>]  ?Color,
+            [<Optional;DefaultParameterValue(null)>]  ?Colors,
             [<Optional;DefaultParameterValue(null)>]  ?Hole,
             [<Optional;DefaultParameterValue(null)>]  ?TextPosition,
             [<Optional;DefaultParameterValue(null)>]  ?TextFont,
@@ -1328,7 +1328,7 @@ type Chart =
             [<Optional;DefaultParameterValue(null)>]  ?Textinfo,
             [<Optional;DefaultParameterValue(null)>]  ?Opacity) =         
         let values,labels = Seq.unzip data 
-        Chart.Doughnut(values,Labels=labels,?Name=Name,?Showlegend=Showlegend,?Color=Color,?Hole=Hole,?TextPosition=TextPosition,?TextFont=TextFont,?Hoverinfo=Hoverinfo,?Textinfo=Textinfo,?Opacity=Opacity)
+        Chart.Doughnut(values,Labels=labels,?Name=Name,?Showlegend=Showlegend,?Colors=Colors,?Hole=Hole,?TextPosition=TextPosition,?TextFont=TextFont,?Hoverinfo=Hoverinfo,?Textinfo=Textinfo,?Opacity=Opacity)
 
 
     /// Uses points, line or both depending on the mode to represent data points in a polar chart

--- a/src/Plotly.NET/Playground.fsx
+++ b/src/Plotly.NET/Playground.fsx
@@ -35,7 +35,7 @@
 #load "Layout.fs"
 #load "Template.fs"
 #load "Config.fs"
-#r @"..\..\packages\Newtonsoft.Json\lib\netstandard2.0\Newtonsoft.Json.dll"
+#r "nuget: Newtonsoft.Json, 12.0.3"
 #load "GenericChart.fs"
 #load "Chart.fs"
 #load "ChartExtensions.fs"
@@ -493,3 +493,21 @@ generateDomainRanges 8 1
     TitleFont=Font.init(Size=20)
 )
 |> Chart.Show
+
+let values,labels = 
+    [
+    1,"v1"
+    2,"v2"
+    ]
+    |> Seq.unzip
+
+let cols =[|"black";"blue"|]
+
+let doughnut1 =
+    Chart.Pie(
+        values,
+        labels,
+        Colors=cols,
+        Textinfo=labels
+    )
+    |> Chart.Show

--- a/src/Plotly.NET/Template.fs
+++ b/src/Plotly.NET/Template.fs
@@ -82,18 +82,41 @@ module ChartTemplates =
         |]
 
     let light = 
-
-        let defaultFont = Font.init (Size = 40)
+        let initLightAxisTemplate() =
+            Axis.LinearAxis.init(
+                Showline =      true,
+                Zeroline =      true
+            )
 
         let defaultLayout = 
             Layout.init (
                 Paper_bgcolor = "white",
-                Plot_bgcolor= "white",
-                Font = defaultFont
+                Plot_bgcolor =  "white"
+            )
+            |> Layout.AddLinearAxis((StyleParam.AxisId.X 1),(initLightAxisTemplate()))
+            |> Layout.AddLinearAxis((StyleParam.AxisId.Y 1),(initLightAxisTemplate()))
+
+        Template.init(defaultLayout)
+
+    let lightMirrored = 
+        let initLightAxisTemplate() =
+            Axis.LinearAxis.init(
+                Showline =      true,
+                Zeroline =      true,
+                Mirror   =      StyleParam.Mirror.All,
+                Ticks    =      StyleParam.TickOptions.Inside
+                //Showgrid =      false
             )
 
+        let defaultLayout = 
+            Layout.init (
+                Paper_bgcolor = "white",
+                Plot_bgcolor =  "white"
+            )
+            |> Layout.AddLinearAxis((StyleParam.AxisId.X 1),(initLightAxisTemplate()))
+            |> Layout.AddLinearAxis((StyleParam.AxisId.Y 1),(initLightAxisTemplate()))
 
-        Template.init(defaultLayout, TraceTemplates = [||])
+        Template.init(defaultLayout)
 
     let dark = 
 
@@ -103,8 +126,9 @@ module ChartTemplates =
                 Zerolinecolor = "rgb(204, 204, 204)",
                 Gridcolor = "rgba(204, 204, 204, 0.3)",
                 Tickcolor = "rgba(204, 204, 204, 0.5)",
-                Showline= true,
-                Zeroline=true
+                Ticks     = StyleParam.TickOptions.Inside,
+                Showline  = true,
+                Zeroline  = true
             )
 
         let darkLayoutTemplate =
@@ -136,22 +160,60 @@ module ChartTemplates =
 
         let initFslabAxisTemplate() =
             Axis.LinearAxis.init(
-                Linecolor = "#438AFE", 
+                Linecolor = "white", 
                 Zerolinecolor = "rgba(67, 138, 254, 0.5)",
                 Gridcolor = "rgba(67, 138, 254, 0.5)",
                 Tickcolor = "rgba(67, 138, 254, 0.5)",
-                Showline= true,
-                Zeroline=true
+                Ticks     = StyleParam.TickOptions.Inside,
+                Showline  = true,
+                Zeroline  = true
             )
 
         let fslabLayoutTemplate =
             Layout.init(
-                Paper_bgcolor = "#2D3E50",
-                Plot_bgcolor= "#2D3E50",
-                Font = Font.init(Color = "#438AFE")
+                Paper_bgcolor = "#200117",
+                Plot_bgcolor= "#200117",
+                Font = Font.init(Color = "white")
             )
             |> Layout.AddLinearAxis((StyleParam.AxisId.X 1),(initFslabAxisTemplate()))
             |> Layout.AddLinearAxis((StyleParam.AxisId.Y 1),(initFslabAxisTemplate()))
 
         Template.init(fslabLayoutTemplate)
         |> Template.withColorWay ColorWays.fslab
+
+
+    let transparent = 
+        let initTransparentAxisTemplate() =
+            Axis.LinearAxis.init(
+                Showline =      true,
+                Zeroline =      true
+            )
+
+        let defaultLayout = 
+            Layout.init (
+                Paper_bgcolor = "rgba(255, 255, 255, 0)",
+                Plot_bgcolor =  "rgba(255, 255, 255, 0)"
+            )
+            |> Layout.AddLinearAxis((StyleParam.AxisId.X 1),(initTransparentAxisTemplate()))
+            |> Layout.AddLinearAxis((StyleParam.AxisId.Y 1),(initTransparentAxisTemplate()))
+
+        Template.init(defaultLayout)
+
+    let transparentMirrored = 
+        let initTransparentAxisTemplate() =
+            Axis.LinearAxis.init(
+                Showline =      true,
+                Zeroline =      true,
+                Mirror   =      StyleParam.Mirror.All,
+                Ticks    =      StyleParam.TickOptions.Inside
+            )
+
+        let defaultLayout = 
+            Layout.init (
+                Paper_bgcolor = "rgba(255, 255, 255, 0)",
+                Plot_bgcolor =  "rgba(255, 255, 255, 0)"
+            )
+            |> Layout.AddLinearAxis((StyleParam.AxisId.X 1),(initTransparentAxisTemplate()))
+            |> Layout.AddLinearAxis((StyleParam.AxisId.Y 1),(initTransparentAxisTemplate()))
+
+        Template.init(defaultLayout)


### PR DESCRIPTION
Relating to #39, no colors could be assigned to pie chart slices. 
Additionally there was a problem in light axis templates #14 with font sizes of 40.

This PR resolves both issues.