### PR TITLE
Unnecessary output type specification removed

### DIFF
--- a/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
+++ b/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
@@ -4,7 +4,6 @@
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
     <NoWarn>$(NoWarn);NU5100</NoWarn><!-- dll outside of lib/ folder -->
-    <OutputType>Library</OutputType>
     <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager to the PDB -->


### PR DESCRIPTION
I'm sorry if this duplicate was intentional, but as far as I know, there is no point to specify the output type of a project twice.