### PR TITLE
Fixing #i rendering

### DIFF
--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -100,7 +100,7 @@ If the interactive extension does not work, please file an issue and we will try
 
 A possible fix for this is the inclusion of Dotnet.Interactive preview package sources. To use these, add the following lines before referencning Plotly.NET.Interactive:
 
-```fsharp
+```
 #i "nuget:https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json"
 #i "nuget:https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 ```


### PR DESCRIPTION
On the docs page, the letter `i` is not rendered for nuget source snippets. This might be because the code snippet language is set to `fsharp`. 

![image](https://user-images.githubusercontent.com/46974588/122970190-962dca00-d35b-11eb-9dfb-1914865eecbc.png)

The NuGet installation snippets don't have `fsharp` as the language of the code snippet and the letter `r` renders correctly. 

![image](https://user-images.githubusercontent.com/46974588/122970215-9f1e9b80-d35b-11eb-9cb6-49d07563e24b.png)

This is a quick fix and might need more investigation on the F# Formatting side.