### PR TITLE
Add OpenGraph properties 

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -6,6 +6,12 @@
     <title>{{fsdocs-page-title}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="author" content="{{fsdocs-authors}}">
+    
+    <!--Opengraph properties (https://ogp.me/)-->
+    <meta property="og:title" content="{{fsdocs-page-title}}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Plotly.NET" />
+    
     <link rel="shortcut icon" type="image/x-icon" href="{{root}}/img/favicon.ico">
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>


### PR DESCRIPTION
Add [OpenGraph](https://ogp.me/) for detailed link rendering on social media / chat apps.

![image](https://user-images.githubusercontent.com/46974588/122978846-ef4e2b80-d364-11eb-8e6b-c917573bca99.png)




