### PR TITLE
Allow custom font family

### DIFF
--- a/src/Plotly.NET/StyleParams.fs
+++ b/src/Plotly.NET/StyleParams.fs
@@ -376,8 +376,22 @@ module StyleParam =
     /// Names of installed font families
     [<RequireQualifiedAccess>]
     type FontFamily =
-        | Arial | Balto | Courier_New | Consolas | Droid_Sans | Droid_Serif | Droid_Sans_Mono | Gravitas_One | Old_Standard_TT | Open_Sans | Overpass | PT_Sans_Narrow | Raleway | Times_New_Roman
-    
+        | Arial
+        | Balto
+        | Courier_New
+        | Consolas
+        | Droid_Sans
+        | Droid_Serif
+        | Droid_Sans_Mono
+        | Gravitas_One
+        | Old_Standard_TT
+        | Open_Sans
+        | Overpass
+        | PT_Sans_Narrow
+        | Raleway
+        | Times_New_Roman
+        | Custom of string
+
         static member toString = function
             | Arial           -> "Arial"
             | Balto           -> "Balto"
@@ -393,6 +407,7 @@ module StyleParam =
             | PT_Sans_Narrow  -> "PT Sans Narrow" 
             | Raleway         -> "Raleway"        
             | Times_New_Roman -> "Times New Roman"
+            | Custom name     -> name
 
         static member convert = FontFamily.toString >> box
 


### PR DESCRIPTION
In order to use Plotly.NET to produce charts that are compatible with corporate design guidelines, this would allow using a custom font-family, outside of the predefined set.