### PR TITLE
Pack script + paths fixed

### DIFF
--- a/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
+++ b/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
@@ -32,8 +32,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="Repack.ps1" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
-    <None Include="..\..\bin\Plotly.NET.Interactive\net5.0\Plotly.NET.Interactive.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    <None Include="..\Plotly.NET.Interactive\bin\Release\$(TargetFramework)\Plotly.NET.Interactive.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Extension.fs" />
   </ItemGroup>

--- a/src/Plotly.NET.Interactive/Repack.ps1
+++ b/src/Plotly.NET.Interactive/Repack.ps1
@@ -1,0 +1,9 @@
+# clean up the previously-cached NuGet packages
+Remove-Item -Recurse ~\.nuget\packages\Plotly.NET.Interactive* -Force
+Remove-Item -Recurse ~\.nuget\packages\Plotly.NET* -Force
+
+# build and pack Plotly.NET.Interactive
+dotnet restore
+dotnet clean
+dotnet build -c Release
+dotnet pack -c Release


### PR DESCRIPTION
Hey. I finally decided to try to contribute to Plotly.NET xD. So I added this script, which may be helpful to reproduce the interactive package for jupyter notebooks. I also fixed paths, but let me know, if I'm blind and doing something wrong.

The script deletes the cached packages (otherwise, when you do `#i "somepath/somefolder"`, it will install the cached package even if you rebuilt it) and packs in release mode.

@kMutagene please, see. I also hope to make something more significant than this (I myself am very interested in .NET doing scientific stuff), just currently looking around at the moment.