### PR TITLE
Another fix to the packing workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ temp/gh-pages
 /src/Plotly.NET.ImageExport/testrenders
 /src/Plotly.NET.Interactive/.local-chromium/
 /docs/.local-chromium/
+
+# Jupyter notebooks checkpoints
+**/.ipynb_checkpoints/**

--- a/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
+++ b/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
@@ -38,6 +38,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="bin\**" />
+    <EmbeddedResource Remove="bin\**" />
+    <None Remove="bin\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Plotly.NET\Plotly.NET.fsproj" />
   </ItemGroup>
 

--- a/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
+++ b/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
@@ -32,15 +32,9 @@
   <ItemGroup>
     <None Include="Repack.ps1" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
-    <None Include="..\Plotly.NET.Interactive\bin\Release\$(TargetFramework)\Plotly.NET.Interactive.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    <None Include="$(OutputPath)/Plotly.NET.Interactive.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Extension.fs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="bin\**" />
-    <EmbeddedResource Remove="bin\**" />
-    <None Remove="bin\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
+++ b/src/Plotly.NET.Interactive/Plotly.NET.Interactive.fsproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <None Include="Repack.ps1" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
-    <None Include="$(OutputPath)/Plotly.NET.Interactive.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    <None Include="..\..\bin\Plotly.NET.Interactive\net5.0\Plotly.NET.Interactive.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Extension.fs" />
   </ItemGroup>

--- a/src/Plotly.NET.Interactive/Repack.ps1
+++ b/src/Plotly.NET.Interactive/Repack.ps1
@@ -8,3 +8,4 @@ cd ../../
 dotnet tool restore
 dotnet fake build
 dotnet pack -c Release -p:PackageVersion=0.0.0-dev -o "./pkg"
+cd src/Plotly.NET.Interactive

--- a/src/Plotly.NET.Interactive/Repack.ps1
+++ b/src/Plotly.NET.Interactive/Repack.ps1
@@ -1,9 +1,10 @@
-# clean up the previously-cached NuGet packages
-Remove-Item -Recurse ~\.nuget\packages\Plotly.NET.Interactive* -Force
-Remove-Item -Recurse ~\.nuget\packages\Plotly.NET* -Force
+# Clean up the previously-cached NuGet packages.
+# Lower-case is intentional (that's how nuget stores those packages).
+Remove-Item -Recurse ~\.nuget\packages\plotly.net.interactive* -Force
+Remove-Item -Recurse ~\.nuget\packages\plotly.net* -Force
 
 # build and pack Plotly.NET.Interactive
 dotnet restore
 dotnet clean
 dotnet build -c Release
-dotnet pack -c Release
+dotnet pack -c Release -p:PackageVersion=0.0.0-dev


### PR DESCRIPTION
In fact... my question is: *how did it even work before?*

What I did is I removed the item group which removed all binaries even from packing. I'm genuinely curious how you packed before - maybe I'm missing something? I tried packing in all possible ways, and it never included the dll into interactive-extensions/dotnet folder. It makes sense, because `<None Remove="bin\**">` removes them as far as I understand 😅 .

@kMutagene please, see