### PR TITLE
Warning-less build?

### DIFF
--- a/src/Plotly.NET/CandelstickExtension.fs
+++ b/src/Plotly.NET/CandelstickExtension.fs
@@ -1,5 +1,16 @@
 ﻿namespace Plotly.NET
 
+
+// This disables FS0044, which is about using
+// obsolete API (marked with Obsolete attribute).
+//
+// It is needed because there are warnings coming
+// from the obsolete functions using obsolete API.
+//
+// However, it will hide using actually obsolete
+// API not used in obsolete API.
+#nowarn "44"
+
 open Trace
 open System
 open System.Runtime.InteropServices

--- a/src/Plotly.NET/CandelstickExtension.fs
+++ b/src/Plotly.NET/CandelstickExtension.fs
@@ -9,6 +9,11 @@
 //
 // However, it will hide using actually obsolete
 // API not used in obsolete API.
+//
+// TODO: remove when 
+// https://github.com/fsharp/fslang-suggestions/issues/278 
+// or https://github.com/fsharp/fslang-suggestions/issues/1055
+// is implemented
 #nowarn "44"
 
 open Trace

--- a/src/Plotly.NET/Chart.fs
+++ b/src/Plotly.NET/Chart.fs
@@ -8,6 +8,11 @@ namespace Plotly.NET
 //
 // However, it will hide using actually obsolete
 // API not used in obsolete API.
+//
+// TODO: remove when 
+// https://github.com/fsharp/fslang-suggestions/issues/278 
+// or https://github.com/fsharp/fslang-suggestions/issues/1055
+// is implemented
 #nowarn "44"
 
 open System

--- a/src/Plotly.NET/Chart.fs
+++ b/src/Plotly.NET/Chart.fs
@@ -1,5 +1,15 @@
 namespace Plotly.NET
 
+// This disables FS0044, which is about using
+// obsolete API (marked with Obsolete attribute).
+//
+// It is needed because there are warnings coming
+// from the obsolete functions using obsolete API.
+//
+// However, it will hide using actually obsolete
+// API not used in obsolete API.
+#nowarn "44"
+
 open System
 open System.IO
 //open FSharp.Care.Collections

--- a/src/Plotly.NET/Plotly.NET.fsproj
+++ b/src/Plotly.NET/Plotly.NET.fsproj
@@ -18,6 +18,12 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Configurations>Debug;Release;Dotnet</Configurations>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  
   <PropertyGroup>
     <Authors>Timo Mühlhaus, Kevin Schneider, F# open source contributors</Authors>
     <Description>plotly.js charts in .NET programming languages 📈🚀. </Description>
@@ -31,6 +37,7 @@
     <FsDocsLicenseLink>https://github.com/plotly/Plotly.NET/blob/dev/LICENSE</FsDocsLicenseLink>
     <FsDocsReleaseNotesLink>https://github.com/plotly/Plotly.NET/blob/dev/RELEASE_NOTES.md</FsDocsReleaseNotesLink>
   </PropertyGroup>
+  
   <ItemGroup>
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
     <Compile Include="AssemblyInfo.fs" />


### PR DESCRIPTION
So the thing is, currently the project builds with warnings. The only warnings that are there are those which are related to using Obsolete API.

There's no way in F# to suppress them locally, as it's being discussed [here](https://github.com/fsharp/fslang-suggestions/issues/278). I even opened a [suggestion](https://github.com/fsharp/fslang-suggestions/issues/1055) for it, but clearly it's not something we're getting soon.

So. I do prefer warning-less projects, and to enforce it, I add treating warnings as errors. However, in F# it would imply suppressing this warning for the whole file, which may accidentally hide this type of warning emitted somewhere (in other words, we exchange `false positive` with `false negative`).

Thoughts?