### PR TITLE
Add Chart.Indicator and related Trace/Layout objects

### DIFF
--- a/Plotly.NET.sln
+++ b/Plotly.NET.sln
@@ -82,6 +82,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{7B09CC0A-F
 		docs\07_0_candlestick.fsx = docs\07_0_candlestick.fsx
 		docs\07_1_funnel.fsx = docs\07_1_funnel.fsx
 		docs\07_2_funnel_area.fsx = docs\07_2_funnel_area.fsx
+		docs\07_3_indicator.fsx = docs\07_3_indicator.fsx
 		docs\08_0_polar_line-scatter-plots.fsx = docs\08_0_polar_line-scatter-plots.fsx
 		docs\08_1_polar_bar_charts.fsx = docs\08_1_polar_bar_charts.fsx
 		docs\08_2_styling_polar_layouts.fsx = docs\08_2_styling_polar_layouts.fsx

--- a/docs/07_3_indicator.fsx
+++ b/docs/07_3_indicator.fsx
@@ -39,40 +39,42 @@ There are different types of indicator charts, depending on the `IndicatorMode` 
 
 open Plotly.NET 
 open Plotly.NET.TraceObjects
+open Plotly.NET.LayoutObjects
 
 let allIndicatorTypes =
     [
         Chart.Indicator(
-            200., StyleParam.IndicatorMode.NumberDeltaGauge,
-            Title = Title.init("Angular gauge showing number and delta")
-            Delta = IndicatorDelta.init(Reference=160),
-            Range = StyleParam.Range.MinMax(0., 250.),
-            Domain = Domain.init(Row = 0, Column = 0)
-        )
-        Chart.Indicator(
             120., StyleParam.IndicatorMode.NumberDeltaGauge,
-            Title = Title.init("Bullet gauge showing number and delta")
+            Title = "Bullet gauge",
             DeltaReference = 90.,
             Range = StyleParam.Range.MinMax(-200., 200.),
             GaugeShape = StyleParam.IndicatorGaugeShape.Bullet,
             ShowGaugeAxis = false,
-            Domain  = Domain.init(Row = 0, Column = 1)
+            Domain  = Domain.init(Row = 0, Column = 0)
+        )
+        Chart.Indicator(
+            200., StyleParam.IndicatorMode.NumberDeltaGauge,
+            Title = "Angular gauge",
+            Delta = IndicatorDelta.init(Reference=160),
+            Range = StyleParam.Range.MinMax(0., 250.),
+            Domain = Domain.init(Row = 0, Column = 1)
         )
         Chart.Indicator(
             300., StyleParam.IndicatorMode.NumberDelta,
-            Title = Title.init("Only showing number and delta")
+            Title = "number and delta",
             DeltaReference = 90.,
             Domain  = Domain.init(Row = 1, Column = 0)
         )        
         Chart.Indicator(
             40., StyleParam.IndicatorMode.Delta,
-            Title = Title.init("Only showing delta")
+            Title = "delta",
             DeltaReference = 90.,
             Domain  = Domain.init(Row = 1, Column = 1)
         )
     ]
     |> Chart.combine
     |> Chart.withLayoutGridStyle(Rows = 2, Columns = 2)
+    |> Chart.withMarginSize(Left = 200)
 
 
 (*** condition: ipynb ***)

--- a/docs/07_3_indicator.fsx
+++ b/docs/07_3_indicator.fsx
@@ -1,0 +1,86 @@
+(**
+---
+title: Indicator Charts
+category: Finance Charts
+categoryindex: 7
+index: 4
+---
+*)
+
+(*** hide ***)
+
+(*** condition: prepare ***)
+#r "nuget: Newtonsoft.JSON, 13.0.1"
+#r "nuget: DynamicObj"
+#r "../bin/Plotly.NET/net5.0/Plotly.NET.dll"
+
+(*** condition: ipynb ***)
+#if IPYNB
+#r "nuget: Plotly.NET, {{fsdocs-package-version}}"
+#r "nuget: Plotly.NET.Interactive, {{fsdocs-package-version}}"
+#endif // IPYNB
+
+(** 
+# Indicator Charts
+
+[![Binder]({{root}}img/badge-binder.svg)](https://mybinder.org/v2/gh/plotly/Plotly.NET/gh-pages?filepath={{fsdocs-source-basename}}.ipynb)&emsp;
+[![Script]({{root}}img/badge-script.svg)]({{root}}{{fsdocs-source-basename}}.fsx)&emsp;
+[![Notebook]({{root}}img/badge-notebook.svg)]({{root}}{{fsdocs-source-basename}}.ipynb)
+
+*Summary:* This example shows how to create indicator charts in F#.
+
+Indicator Charts visualize the evolution of a value compared to a reference value, optionally inside a range.
+
+There are different types of indicator charts, depending on the `IndicatorMode` used in chart generation:
+
+- `Delta`/`Number` (and combinations) simply shows if the value is increasing or decreasing compared to the reference
+- Any combination of the above with `Gauge` adds a customizable gauge that indicates where the value lies inside a given range.
+*)
+
+open Plotly.NET 
+open Plotly.NET.TraceObjects
+
+let allIndicatorTypes =
+    [
+        Chart.Indicator(
+            200., StyleParam.IndicatorMode.NumberDeltaGauge,
+            Title = Title.init("Angular gauge showing number and delta")
+            Delta = IndicatorDelta.init(Reference=160),
+            Range = StyleParam.Range.MinMax(0., 250.),
+            Domain = Domain.init(Row = 0, Column = 0)
+        )
+        Chart.Indicator(
+            120., StyleParam.IndicatorMode.NumberDeltaGauge,
+            Title = Title.init("Bullet gauge showing number and delta")
+            DeltaReference = 90.,
+            Range = StyleParam.Range.MinMax(-200., 200.),
+            GaugeShape = StyleParam.IndicatorGaugeShape.Bullet,
+            ShowGaugeAxis = false,
+            Domain  = Domain.init(Row = 0, Column = 1)
+        )
+        Chart.Indicator(
+            300., StyleParam.IndicatorMode.NumberDelta,
+            Title = Title.init("Only showing number and delta")
+            DeltaReference = 90.,
+            Domain  = Domain.init(Row = 1, Column = 0)
+        )        
+        Chart.Indicator(
+            40., StyleParam.IndicatorMode.Delta,
+            Title = Title.init("Only showing delta")
+            DeltaReference = 90.,
+            Domain  = Domain.init(Row = 1, Column = 1)
+        )
+    ]
+    |> Chart.combine
+    |> Chart.withLayoutGridStyle(Rows = 2, Columns = 2)
+
+
+(*** condition: ipynb ***)
+#if IPYNB
+allIndicatorTypes
+#endif // IPYNB
+
+(***hide***)
+allIndicatorTypes |> GenericChart.toChartHTML
+(***include-it-raw***)
+

--- a/src/Plotly.NET/ChartAPI/ChartDomain.fs
+++ b/src/Plotly.NET/ChartAPI/ChartDomain.fs
@@ -509,3 +509,54 @@ module ChartDomain =
                         )
                     )
                 |> GenericChart.ofTraceObject 
+
+        /// creates table out of header sequence and row sequences
+        [<Extension>]
+        static member Indicator
+            (
+               value      : #IConvertible,
+               mode       : StyleParam.IndicatorMode,
+               [<Optional;DefaultParameterValue(null)>] ?Range          : StyleParam.Range,
+               [<Optional;DefaultParameterValue(null)>] ?Name           : string,
+               [<Optional;DefaultParameterValue(null)>] ?Title          : string,
+               [<Optional;DefaultParameterValue(null)>] ?ShowLegend     : bool,
+               [<Optional;DefaultParameterValue(null)>] ?Domain         : Domain,
+               [<Optional;DefaultParameterValue(null)>] ?Align          : StyleParam.IndicatorAlignment,
+               [<Optional;DefaultParameterValue(null)>] ?DeltaReference : #IConvertible,
+               [<Optional;DefaultParameterValue(null)>] ?Delta          : IndicatorDelta,
+               [<Optional;DefaultParameterValue(null)>] ?Number         : IndicatorNumber,
+               [<Optional;DefaultParameterValue(null)>] ?GaugeShape     : StyleParam.IndicatorGaugeShape,
+               [<Optional;DefaultParameterValue(null)>] ?Gauge          : IndicatorGauge,
+               [<Optional;DefaultParameterValue(null)>] ?ShowGaugeAxis  : bool,
+               [<Optional;DefaultParameterValue(null)>] ?GaugeAxis      : LinearAxis
+            ) = 
+                let axis = 
+                    GaugeAxis
+                    |> Option.defaultValue(LinearAxis.init())
+                    |> LinearAxis.style(?Range=Range, ?Visible=ShowGaugeAxis)
+
+                let gauge =
+                    Gauge
+                    |> Option.defaultValue(IndicatorGauge.init())
+                    |> IndicatorGauge.style(Axis=axis, ?Shape=GaugeShape)
+
+                let delta =
+                    Delta
+                    |> Option.defaultValue(IndicatorDelta.init())
+                    |> IndicatorDelta.style(?Reference = DeltaReference)
+
+                TraceDomain.initIndicator(
+                    TraceDomainStyle.Indicator(
+                        ?Name       = Name      ,
+                        ?Title      = Title     ,
+                        ?ShowLegend = ShowLegend,
+                        Mode        = mode      ,
+                        Value       = value     ,
+                        ?Domain     = Domain    ,
+                        ?Align      = Align     ,
+                        Delta       = delta     ,
+                        ?Number     = Number    ,
+                        Gauge       = gauge     
+                    )
+                )
+                |> GenericChart.ofTraceObject

--- a/src/Plotly.NET/ChartAPI/ChartDomain.fs
+++ b/src/Plotly.NET/ChartAPI/ChartDomain.fs
@@ -514,7 +514,7 @@ module ChartDomain =
         [<Extension>]
         static member Indicator
             (
-               value      : #IConvertible,
+               value      : IConvertible,
                mode       : StyleParam.IndicatorMode,
                [<Optional;DefaultParameterValue(null)>] ?Range          : StyleParam.Range,
                [<Optional;DefaultParameterValue(null)>] ?Name           : string,

--- a/src/Plotly.NET/CommonAbstractions/StyleParams.fs
+++ b/src/Plotly.NET/CommonAbstractions/StyleParams.fs
@@ -1115,6 +1115,61 @@ module StyleParam =
 //--------------------------
 
     [<RequireQualifiedAccess>]
+    type IndicatorMode =
+        | Number | Delta | Gauge
+        | NumberDelta | NumberGauge
+        | DeltaGauge
+        | NumberDeltaGauge
+        static member toString = function
+            | Number            -> "number"
+            | Delta             -> "delta"
+            | Gauge             -> "gauge"
+            | NumberDelta       -> "number+delta"
+            | NumberGauge      -> "number+gauge"
+            | DeltaGauge        -> "delta+gauge"
+            | NumberDeltaGauge  -> "number+delta+gauge"
+
+        static member convert = IndicatorMode.toString >> box
+        override this.ToString() = this |> IndicatorMode.toString
+        member this.Convert() = this |> IndicatorMode.convert
+        
+    [<RequireQualifiedAccess>]
+    type IndicatorAlignment =
+        | Left | Center | Right
+        static member toString = function
+            | Left  -> "left"
+            | Center-> "center" 
+            | Right -> "right"
+
+        static member convert = IndicatorAlignment.toString >> box
+        override this.ToString() = this |> IndicatorAlignment.toString
+        member this.Convert() = this |> IndicatorAlignment.convert
+        
+    [<RequireQualifiedAccess>]
+    type IndicatorGaugeShape =
+        | Angular | Bullet 
+        static member toString = function
+            | Angular   -> "angular"
+            | Bullet    -> "bullet"
+
+        static member convert = IndicatorGaugeShape.toString >> box
+        override this.ToString() = this |> IndicatorGaugeShape.toString
+        member this.Convert() = this |> IndicatorGaugeShape.convert
+        
+    [<RequireQualifiedAccess>]
+    type IndicatorDeltaPosition =
+        | Top | Bottom | Left | Right
+        static member toString = function
+            | Top       -> "top"
+            | Bottom    -> "bottom"
+            | Left      -> "left"
+            | Right     -> "right"
+
+        static member convert = IndicatorDeltaPosition.toString >> box
+        override this.ToString() = this |> IndicatorDeltaPosition.toString
+        member this.Convert() = this |> IndicatorDeltaPosition.convert
+        
+    [<RequireQualifiedAccess>]
     type InsideTextAnchor =
         | End | Middle | Start
         static member toString = function

--- a/src/Plotly.NET/Layout/ObjectAbstractions/Common/LinearAxis.fs
+++ b/src/Plotly.NET/Layout/ObjectAbstractions/Common/LinearAxis.fs
@@ -116,8 +116,8 @@ type LinearAxis () =
             [<Optional;DefaultParameterValue(null)>] ?TickLabelPosition  : StyleParam.TickLabelPosition,
             [<Optional;DefaultParameterValue(null)>] ?TickLabelOverflow  : StyleParam.TickLabelOverflow,
             [<Optional;DefaultParameterValue(null)>] ?Mirror             : StyleParam.Mirror,           
-            [<Optional;DefaultParameterValue(null)>] ?TickLen            : float,
-            [<Optional;DefaultParameterValue(null)>] ?TickWidth          : float,        
+            [<Optional;DefaultParameterValue(null)>] ?TickLen            : int,
+            [<Optional;DefaultParameterValue(null)>] ?TickWidth          : int,        
             [<Optional;DefaultParameterValue(null)>] ?TickColor          : Color,        
             [<Optional;DefaultParameterValue(null)>] ?ShowTickLabels     : bool,   
             [<Optional;DefaultParameterValue(null)>] ?AutoMargin         : bool,
@@ -352,8 +352,8 @@ type LinearAxis () =
             [<Optional;DefaultParameterValue(null)>] ?TickLabelPosition  : StyleParam.TickLabelPosition,
             [<Optional;DefaultParameterValue(null)>] ?TickLabelOverflow  : StyleParam.TickLabelOverflow,
             [<Optional;DefaultParameterValue(null)>] ?Mirror             : StyleParam.Mirror,           
-            [<Optional;DefaultParameterValue(null)>] ?TickLen            : float,
-            [<Optional;DefaultParameterValue(null)>] ?TickWidth          : float,        
+            [<Optional;DefaultParameterValue(null)>] ?TickLen            : int,
+            [<Optional;DefaultParameterValue(null)>] ?TickWidth          : int,        
             [<Optional;DefaultParameterValue(null)>] ?TickColor          : Color,        
             [<Optional;DefaultParameterValue(null)>] ?ShowTickLabels     : bool,   
             [<Optional;DefaultParameterValue(null)>] ?AutoMargin         : bool,
@@ -480,7 +480,7 @@ type LinearAxis () =
                     ?Calendar           = Calendar           
                 )
     /// <summary>
-    /// Initialize a LinearAxis object that can be used as a positional scale for Y, X or Z coordinates.
+    /// Initialize a LinearAxis object that can be used as a positional scale for carpet plots.
     /// </summary>
     /// <param name="Color">Sets default for all colors associated with this axis all at once: line, font, tick, and grid colors. Grid color is lightened by blending this with the plot background Individual pieces can override this.</param>
     /// <param name="Title">Sets the axis title.</param>
@@ -647,6 +647,93 @@ type LinearAxis () =
                     ?StartLineColor    = StartLineColor    ,
                     ?StartLineWidth    = StartLineWidth    
                 )
+    
+    /// <summary>
+    /// Initialize a LinearAxis object that can be used as a positional scale for indicator gauges.
+    /// </summary>
+    /// <param name="DTick">Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to "log" and "date" axes. If the axis `type` is "log", then ticks are set every 10^(n"dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. "log" has several special values; "L&lt;f&gt;", where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = "L0.5" will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use "D1" (all digits) or "D2" (only 2 and 5). `tick0` is ignored for "D1" and "D2". If the axis `type` is "date", then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. "date" also has special values "M&lt;n&gt;" gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to "2000-01-15" and `dtick` to "M3". To set ticks every 4 years, set `dtick` to "M48"</param>
+    /// <param name="Range">Sets the range of this axis. If the axis `type` is "log", then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is "date", it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is "category", it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.</param>
+    /// <param name="TickMode">Sets the tick mode for this axis. If "auto", the number of ticks is set via `nticks`. If "linear", the placement of the ticks is determined by a starting position `tick0` and a tick step `dtick` ("linear" is the default value if `tick0` and `dtick` are provided). If "array", the placement of the ticks is set via `TickVals` and the tick text is `TickText`. ("array" is the default value if `TickVals` is provided).</param>
+    /// <param name="NTicks">Specifies the maximum number of ticks for the particular axis. The actual number of ticks will be chosen automatically to be less than or equal to `nticks`. Has an effect only if `tickmode` is set to "auto".</param>
+    /// <param name="Tick0">Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is "log", then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`="L&lt;f&gt;" (see `dtick` for more info). If the axis `type` is "date", it should be a date string, like date data. If the axis `type` is "category", it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.</param>
+    /// <param name="TickVals">Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to "array". Used with `TickText`.</param>
+    /// <param name="TickText">Sets the text displayed at the ticks position via `TickVals`. Only has an effect if `tickmode` is set to "array". Used with `TickVals`.</param>
+    /// <param name="Ticks">Determines whether ticks are drawn or not. If "", this axis' ticks are not drawn. If "outside" ("inside"), this axis' are drawn outside (inside) the axis lines.</param>
+    /// <param name="ShowTickLabels">Determines whether or not the tick labels are drawn.</param>
+    /// <param name="TickFont">Sets the tick font.</param>
+    /// <param name="TickAngle">Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.</param>
+    /// <param name="ShowTickPrefix">If "all", all tick labels are displayed with a prefix. If "first", only the first tick is displayed with a prefix. If "last", only the last tick is displayed with a suffix. If "none", tick prefixes are hidden.</param>
+    /// <param name="TickPrefix">Sets a tick label prefix.</param>
+    /// <param name="ShowTickSuffix">Same as `showtickprefix` but for tick suffixes.</param>
+    /// <param name="TickSuffix">Sets a tick label suffix.</param>
+    /// <param name="ShowExponent">If "all", all exponents are shown besides their significands. If "first", only the exponent of the first tick is shown. If "last", only the exponent of the last tick is shown. If "none", no exponents appear.</param>
+    /// <param name="ExponentFormat">Determines a formatting rule for the tick exponents. For example, consider the number 1,000,000,000. If "none", it appears as 1,000,000,000. If "e", 1e+9. If "E", 1E+9. If "power", 1x10^9 (with 9 in a super script). If "SI", 1G. If "B", 1B.</param>
+    /// <param name="MinExponent">Hide SI prefix for 10^n if |n| is below this number. This only has an effect when `TickFormat` is "SI" or "B".</param>
+    /// <param name="SeparateThousands">If "true", even 4-digit integers are separated</param>
+    /// <param name="TickFormat">Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format. And for dates see: https://github.com/d3/d3-time-format#locale_format. We add two items to d3's date formatter: "%h" for half of the year as a decimal number as well as "%{n}f" for fractional seconds with n digits. For example, "2016-10-13 09:15:23.456" with TickFormat "%H~%M~%S.%2f" would display "09~15~23.46"</param>
+    /// <param name="TickLen">Sets the tick length (in px).</param>
+    /// <param name="TickWidth">Sets the tick width (in px).</param>
+    /// <param name="TickColor">Sets the tick color.</param>
+    /// <param name="TickFormatStops">Set rules for customizing TickFormat on different zoom levels</param>
+    /// <param name="Visible">A single toggle to hide the axis while preserving interaction like dragging. Default is true when a cheater plot is present on the axis, otherwise false</param>
+    static member initIndicatorGauge
+        (
+            [<Optional;DefaultParameterValue(null)>] ?DTick             : #IConvertible,            
+            [<Optional;DefaultParameterValue(null)>] ?ExponentFormat    : StyleParam.ExponentFormat,
+            [<Optional;DefaultParameterValue(null)>] ?MinExponent       : float,
+            [<Optional;DefaultParameterValue(null)>] ?NTicks            : int,           
+            [<Optional;DefaultParameterValue(null)>] ?Range             : StyleParam.Range,            
+            [<Optional;DefaultParameterValue(null)>] ?SeparateThousands : bool,
+            [<Optional;DefaultParameterValue(null)>] ?ShowExponent      : StyleParam.ShowExponent,
+            [<Optional;DefaultParameterValue(null)>] ?ShowTickLabels    : bool,   
+            [<Optional;DefaultParameterValue(null)>] ?ShowTickPrefix    : StyleParam.ShowTickOption,   
+            [<Optional;DefaultParameterValue(null)>] ?ShowTickSuffix    : StyleParam.ShowTickOption,
+            [<Optional;DefaultParameterValue(null)>] ?Tick0             : #IConvertible,            
+            [<Optional;DefaultParameterValue(null)>] ?TickAngle         : int,        
+            [<Optional;DefaultParameterValue(null)>] ?TickColor         : Color,        
+            [<Optional;DefaultParameterValue(null)>] ?TickFont          : Font,         
+            [<Optional;DefaultParameterValue(null)>] ?TickFormat        : string,       
+            [<Optional;DefaultParameterValue(null)>] ?TickFormatStops   : seq<TickFormatStop>,
+            [<Optional;DefaultParameterValue(null)>] ?TickLen           : int,
+            [<Optional;DefaultParameterValue(null)>] ?TickMode          : StyleParam.TickMode,         
+            [<Optional;DefaultParameterValue(null)>] ?TickPrefix        : string,
+            [<Optional;DefaultParameterValue(null)>] ?Ticks             : StyleParam.TickOptions,            
+            [<Optional;DefaultParameterValue(null)>] ?TickSuffix        : string,
+            [<Optional;DefaultParameterValue(null)>] ?TickText          : seq<#IConvertible>,         
+            [<Optional;DefaultParameterValue(null)>] ?TickVals          : seq<#IConvertible>,         
+            [<Optional;DefaultParameterValue(null)>] ?TickWidth         : int,         
+            [<Optional;DefaultParameterValue(null)>] ?Visible           : bool
+
+        ) =
+            LinearAxis() 
+            |> LinearAxis.style
+                (
+                    ?DTick             = DTick             ,
+                    ?ExponentFormat    = ExponentFormat    ,
+                    ?MinExponent       = MinExponent       ,
+                    ?NTicks            = NTicks            ,
+                    ?Range             = Range             ,
+                    ?SeparateThousands = SeparateThousands ,
+                    ?ShowExponent      = ShowExponent      ,
+                    ?ShowTickLabels    = ShowTickLabels    ,
+                    ?ShowTickPrefix    = ShowTickPrefix    ,
+                    ?ShowTickSuffix    = ShowTickSuffix    ,
+                    ?Tick0             = Tick0             ,
+                    ?TickAngle         = TickAngle         ,
+                    ?TickColor         = TickColor         ,
+                    ?TickFont          = TickFont          ,
+                    ?TickFormat        = TickFormat        ,
+                    ?TickFormatStops   = TickFormatStops   ,
+                    ?TickLen           = TickLen           ,
+                    ?TickMode          = TickMode          ,
+                    ?TickPrefix        = TickPrefix        ,
+                    ?Ticks             = Ticks             ,
+                    ?TickSuffix        = TickSuffix        ,
+                    ?TickText          = TickText          ,
+                    ?TickVals          = TickVals          ,
+                    ?TickWidth         = TickWidth         ,
+                    ?Visible           = Visible           
+                )
     /// <summary>
     /// Create a function that applies the given style parameters to a LinearAxis object
     /// </summary>
@@ -772,8 +859,8 @@ type LinearAxis () =
             [<Optional;DefaultParameterValue(null)>] ?TickLabelPosition : StyleParam.TickLabelPosition,
             [<Optional;DefaultParameterValue(null)>] ?TickLabelOverflow : StyleParam.TickLabelOverflow,
             [<Optional;DefaultParameterValue(null)>] ?Mirror            : StyleParam.Mirror,           
-            [<Optional;DefaultParameterValue(null)>] ?TickLen           : float,
-            [<Optional;DefaultParameterValue(null)>] ?TickWidth         : float,        
+            [<Optional;DefaultParameterValue(null)>] ?TickLen           : int,
+            [<Optional;DefaultParameterValue(null)>] ?TickWidth         : int,        
             [<Optional;DefaultParameterValue(null)>] ?TickColor         : Color,        
             [<Optional;DefaultParameterValue(null)>] ?ShowTickLabels    : bool,   
             [<Optional;DefaultParameterValue(null)>] ?AutoMargin        : bool,

--- a/src/Plotly.NET/Playground.fsx
+++ b/src/Plotly.NET/Playground.fsx
@@ -161,22 +161,22 @@ open System
 open System.IO
 
 [
-    Chart.Indicator(
+    ChartDomain.Chart.Indicator(
         200., StyleParam.IndicatorMode.NumberDeltaGauge,
         Delta   = IndicatorDelta.init(Reference=160),
         Range   = StyleParam.Range.MinMax(0., 250.),
         Domain  = Domain.init(Row = 0, Column = 0)
     )
     Chart.Indicator(
-        120., StyleParam.IndicatorMode.NumberDeltaGauge,
-        DeltaReference = 90.,
+        120, StyleParam.IndicatorMode.NumberDeltaGauge,
+        DeltaReference = 90,
         Range = StyleParam.Range.MinMax(-200., 200.),
         GaugeShape = StyleParam.IndicatorGaugeShape.Bullet,
         ShowGaugeAxis = false,
         Domain  = Domain.init(Row = 0, Column = 1)
     )
     Chart.Indicator(
-        300., StyleParam.IndicatorMode.NumberDelta,
+        "300", StyleParam.IndicatorMode.NumberDelta,
         DeltaReference = 90.,
         Domain  = Domain.init(Row = 1, Column = 0)
     )        

--- a/src/Plotly.NET/Playground.fsx
+++ b/src/Plotly.NET/Playground.fsx
@@ -161,33 +161,38 @@ open System
 open System.IO
 
 [
-    ChartDomain.Chart.Indicator(
-        200., StyleParam.IndicatorMode.NumberDeltaGauge,
-        Delta   = IndicatorDelta.init(Reference=160),
-        Range   = StyleParam.Range.MinMax(0., 250.),
-        Domain  = Domain.init(Row = 0, Column = 0)
-    )
     Chart.Indicator(
-        120, StyleParam.IndicatorMode.NumberDeltaGauge,
-        DeltaReference = 90,
+        120., StyleParam.IndicatorMode.NumberDeltaGauge,
+        Title = "Bullet gauge",
+        DeltaReference = 90.,
         Range = StyleParam.Range.MinMax(-200., 200.),
         GaugeShape = StyleParam.IndicatorGaugeShape.Bullet,
         ShowGaugeAxis = false,
-        Domain  = Domain.init(Row = 0, Column = 1)
+        Domain  = Domain.init(Row = 0, Column = 0)
     )
     Chart.Indicator(
-        "300", StyleParam.IndicatorMode.NumberDelta,
+        200., StyleParam.IndicatorMode.NumberDeltaGauge,
+        Title = "Angular gauge",
+        Delta = IndicatorDelta.init(Reference=160),
+        Range = StyleParam.Range.MinMax(0., 250.),
+        Domain = Domain.init(Row = 0, Column = 1)
+    )
+    Chart.Indicator(
+        300., StyleParam.IndicatorMode.NumberDelta,
+        Title = "number and delta",
         DeltaReference = 90.,
         Domain  = Domain.init(Row = 1, Column = 0)
     )        
     Chart.Indicator(
         40., StyleParam.IndicatorMode.Delta,
+        Title = "delta",
         DeltaReference = 90.,
         Domain  = Domain.init(Row = 1, Column = 1)
     )
 ]
 |> Chart.combine
 |> Chart.withLayoutGridStyle(Rows = 2, Columns = 2)
+|> Chart.withMarginSize(Left = 200)
 |> Chart.show
 
 

--- a/src/Plotly.NET/Playground.fsx
+++ b/src/Plotly.NET/Playground.fsx
@@ -92,6 +92,7 @@
 #load "Cumulative.fs"
 #load "Error.fs"
 #load "Table.fs"
+#load "Indicator.fs"
 
 #I "Traces"
 
@@ -158,6 +159,37 @@ open FSharpAux
 
 open System
 open System.IO
+
+[
+    Chart.Indicator(
+        200., StyleParam.IndicatorMode.NumberDeltaGauge,
+        Delta   = IndicatorDelta.init(Reference=160),
+        Range   = StyleParam.Range.MinMax(0., 250.),
+        Domain  = Domain.init(Row = 0, Column = 0)
+    )
+    Chart.Indicator(
+        120., StyleParam.IndicatorMode.NumberDeltaGauge,
+        DeltaReference = 90.,
+        Range = StyleParam.Range.MinMax(-200., 200.),
+        GaugeShape = StyleParam.IndicatorGaugeShape.Bullet,
+        ShowGaugeAxis = false,
+        Domain  = Domain.init(Row = 0, Column = 1)
+    )
+    Chart.Indicator(
+        300., StyleParam.IndicatorMode.NumberDelta,
+        DeltaReference = 90.,
+        Domain  = Domain.init(Row = 1, Column = 0)
+    )        
+    Chart.Indicator(
+        40., StyleParam.IndicatorMode.Delta,
+        DeltaReference = 90.,
+        Domain  = Domain.init(Row = 1, Column = 1)
+    )
+]
+|> Chart.combine
+|> Chart.withLayoutGridStyle(Rows = 2, Columns = 2)
+|> Chart.show
+
 
 [
     Chart.Carpet(

--- a/src/Plotly.NET/Plotly.NET.fsproj
+++ b/src/Plotly.NET/Plotly.NET.fsproj
@@ -100,6 +100,7 @@
     <Compile Include="Traces\ObjectAbstractions\Cumulative.fs" />
     <Compile Include="Traces\ObjectAbstractions\Error.fs" />
     <Compile Include="Traces\ObjectAbstractions\Table.fs" />
+    <Compile Include="Traces\ObjectAbstractions\Indicator.fs" />
     <Compile Include="Traces\Trace.fs" />
     <Compile Include="Traces\Trace2D.fs" />
     <Compile Include="Traces\Trace3D.fs" />

--- a/src/Plotly.NET/Traces/ObjectAbstractions/Indicator.fs
+++ b/src/Plotly.NET/Traces/ObjectAbstractions/Indicator.fs
@@ -1,0 +1,287 @@
+﻿namespace Plotly.NET.TraceObjects
+
+open Plotly.NET
+open Plotly.NET.LayoutObjects
+open DynamicObj
+open System
+open System.Runtime.InteropServices
+
+
+type IndicatorSymbol () =
+    inherit DynamicObj ()
+
+    static member init
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Color  : Color,
+            [<Optional;DefaultParameterValue(null)>] ?Symbol : string
+        ) =
+            IndicatorSymbol () 
+            |> IndicatorSymbol.style
+                (
+                    ?Color = Color,
+                    ?Symbol= Symbol
+                )
+
+    static member style
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Color  : Color,
+            [<Optional;DefaultParameterValue(null)>] ?Symbol : string
+        ) =
+            (fun (indicatorDirection: IndicatorSymbol) -> 
+
+                Color   |> DynObj.setValueOpt indicatorDirection "color"
+                Symbol  |> DynObj.setValueOpt indicatorDirection "symbol"
+
+                indicatorDirection
+            )
+
+type IndicatorDelta () =
+    inherit DynamicObj ()
+
+    static member init
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Decreasing : IndicatorSymbol,
+            [<Optional;DefaultParameterValue(null)>] ?Font       : Font,
+            [<Optional;DefaultParameterValue(null)>] ?Increasing : IndicatorSymbol,
+            [<Optional;DefaultParameterValue(null)>] ?Position   : StyleParam.IndicatorDeltaPosition,
+            [<Optional;DefaultParameterValue(null)>] ?Reference  : #IConvertible,
+            [<Optional;DefaultParameterValue(null)>] ?Relative   : bool,
+            [<Optional;DefaultParameterValue(null)>] ?ValueFormat: string
+
+        ) =
+            IndicatorDelta () 
+            |> IndicatorDelta.style
+                (
+                    ?Decreasing     = Decreasing ,
+                    ?Font           = Font       ,
+                    ?Increasing     = Increasing ,
+                    ?Position       = Position   ,
+                    ?Reference      = Reference  ,
+                    ?Relative       = Relative   ,
+                    ?ValueFormat    = ValueFormat
+                )
+
+    static member style
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Decreasing : IndicatorSymbol,
+            [<Optional;DefaultParameterValue(null)>] ?Font       : Font,
+            [<Optional;DefaultParameterValue(null)>] ?Increasing : IndicatorSymbol,
+            [<Optional;DefaultParameterValue(null)>] ?Position   : StyleParam.IndicatorDeltaPosition,
+            [<Optional;DefaultParameterValue(null)>] ?Reference  : #IConvertible,
+            [<Optional;DefaultParameterValue(null)>] ?Relative   : bool,
+            [<Optional;DefaultParameterValue(null)>] ?ValueFormat: string
+        ) =
+            (fun (indicatorDelta: IndicatorDelta) -> 
+
+                Decreasing  |> DynObj.setValueOpt indicatorDelta "decreasing"
+                Font        |> DynObj.setValueOpt indicatorDelta "font"
+                Increasing  |> DynObj.setValueOpt indicatorDelta "increasing"
+                Position    |> DynObj.setValueOptBy indicatorDelta "position" StyleParam.IndicatorDeltaPosition.convert
+                Reference   |> DynObj.setValueOpt indicatorDelta "reference"
+                Relative    |> DynObj.setValueOpt indicatorDelta "relative"
+                ValueFormat |> DynObj.setValueOpt indicatorDelta "valueformat"
+
+                indicatorDelta
+            )
+
+type IndicatorNumber () =
+    inherit DynamicObj ()
+
+    static member init
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Font       : Font,
+            [<Optional;DefaultParameterValue(null)>] ?Prefix     : string,
+            [<Optional;DefaultParameterValue(null)>] ?Suffix     : string,
+            [<Optional;DefaultParameterValue(null)>] ?ValueFormat: string
+
+        ) =
+            IndicatorNumber () 
+            |> IndicatorNumber.style
+                (
+                    ?Font       = Font       ,
+                    ?Prefix     = Prefix     ,
+                    ?Suffix     = Suffix     ,
+                    ?ValueFormat= ValueFormat
+                )
+
+    static member style
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Font       : Font,
+            [<Optional;DefaultParameterValue(null)>] ?Prefix     : string,
+            [<Optional;DefaultParameterValue(null)>] ?Suffix     : string,
+            [<Optional;DefaultParameterValue(null)>] ?ValueFormat: string
+        ) =
+            (fun (indicatorNumber: IndicatorNumber) -> 
+
+                Font       |> DynObj.setValueOpt indicatorNumber "font"
+                Prefix     |> DynObj.setValueOpt indicatorNumber "prefix"
+                Suffix     |> DynObj.setValueOpt indicatorNumber "suffix"
+                ValueFormat|> DynObj.setValueOpt indicatorNumber "valueformat"
+
+                indicatorNumber
+            )
+
+
+type IndicatorBar () =
+    inherit DynamicObj ()
+
+    static member init
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Color      : Color,
+            [<Optional;DefaultParameterValue(null)>] ?Line       : Line,
+            [<Optional;DefaultParameterValue(null)>] ?Thickness  : float
+        ) =
+            IndicatorBar () 
+            |> IndicatorBar.style
+                (
+                    ?Color      = Color    ,
+                    ?Line       = Line     ,
+                    ?Thickness  = Thickness
+                )
+
+    static member style
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Color      : Color,
+            [<Optional;DefaultParameterValue(null)>] ?Line       : Line,
+            [<Optional;DefaultParameterValue(null)>] ?Thickness  : float
+        ) =
+            (fun (indicatorBar: IndicatorBar) -> 
+                
+                Color       |> DynObj.setValueOpt indicatorBar "color"
+                Line        |> DynObj.setValueOpt indicatorBar "line"
+                Thickness   |> DynObj.setValueOpt indicatorBar "thickness"
+
+                indicatorBar
+            )
+
+type IndicatorSteps () =
+    inherit DynamicObj ()
+
+    static member init
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Color             : Color,
+            [<Optional;DefaultParameterValue(null)>] ?Line              : Line,
+            [<Optional;DefaultParameterValue(null)>] ?Name              : string,
+            [<Optional;DefaultParameterValue(null)>] ?Range             : StyleParam.Range,
+            [<Optional;DefaultParameterValue(null)>] ?TemplateItemName  : string,
+            [<Optional;DefaultParameterValue(null)>] ?Thickness         : float
+
+        ) =
+            IndicatorSteps () 
+            |> IndicatorSteps.style
+                (
+                    ?Color             = Color             ,
+                    ?Line              = Line              ,
+                    ?Name              = Name              ,
+                    ?Range             = Range             ,
+                    ?TemplateItemName  = TemplateItemName  ,
+                    ?Thickness         = Thickness         
+                )
+
+    static member style
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Color             : Color,
+            [<Optional;DefaultParameterValue(null)>] ?Line              : Line,
+            [<Optional;DefaultParameterValue(null)>] ?Name              : string,
+            [<Optional;DefaultParameterValue(null)>] ?Range             : StyleParam.Range,
+            [<Optional;DefaultParameterValue(null)>] ?TemplateItemName  : string,
+            [<Optional;DefaultParameterValue(null)>] ?Thickness         : float
+        ) =
+            (fun (indicatorSteps: IndicatorSteps) -> 
+                
+                Color              |> DynObj.setValueOpt indicatorSteps "color"
+                Line               |> DynObj.setValueOpt indicatorSteps "line"
+                Name               |> DynObj.setValueOpt indicatorSteps "name"
+                Range              |> DynObj.setValueOptBy indicatorSteps "range" StyleParam.Range.convert
+                TemplateItemName   |> DynObj.setValueOpt indicatorSteps "templateitemname"
+                Thickness          |> DynObj.setValueOpt indicatorSteps "thickness"
+
+                indicatorSteps
+            )
+
+
+type IndicatorThreshold () =
+    inherit DynamicObj ()
+
+    static member init
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Line      : Line,
+            [<Optional;DefaultParameterValue(null)>] ?Thickness : float,
+            [<Optional;DefaultParameterValue(null)>] ?Value     : #IConvertible
+
+        ) =
+            IndicatorThreshold () 
+            |> IndicatorThreshold.style
+                (
+                    ?Line       = Line     ,
+                    ?Thickness  = Thickness,         
+                    ?Value      = Value
+                )
+
+    static member style
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Line      : Line,
+            [<Optional;DefaultParameterValue(null)>] ?Thickness : float,
+            [<Optional;DefaultParameterValue(null)>] ?Value     : #IConvertible
+        ) =
+            (fun (indicatorThreshold: IndicatorThreshold) -> 
+                
+                Line        |> DynObj.setValueOpt indicatorThreshold "line"
+                Thickness   |> DynObj.setValueOpt indicatorThreshold "thickness"
+                Value       |> DynObj.setValueOpt indicatorThreshold "value"
+
+                indicatorThreshold
+            )
+
+
+type IndicatorGauge () =
+    inherit DynamicObj ()
+
+    static member init
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Axis       : LinearAxis,
+            [<Optional;DefaultParameterValue(null)>] ?Bar        : IndicatorBar,
+            [<Optional;DefaultParameterValue(null)>] ?BGColor    : Color,
+            [<Optional;DefaultParameterValue(null)>] ?BorderColor: Color,
+            [<Optional;DefaultParameterValue(null)>] ?BorderWidth: int,
+            [<Optional;DefaultParameterValue(null)>] ?Shape      : StyleParam.IndicatorGaugeShape,
+            [<Optional;DefaultParameterValue(null)>] ?Steps      : IndicatorSteps,
+            [<Optional;DefaultParameterValue(null)>] ?Threshold  : IndicatorThreshold
+        ) =
+            IndicatorGauge () 
+            |> IndicatorGauge.style
+                (
+                    ?Axis       = Axis       ,
+                    ?Bar        = Bar        ,
+                    ?BGColor    = BGColor    ,
+                    ?BorderColor= BorderColor,
+                    ?BorderWidth= BorderWidth,
+                    ?Shape      = Shape      ,
+                    ?Steps      = Steps      ,
+                    ?Threshold  = Threshold  
+                )
+
+    static member style
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Axis       : LinearAxis,
+            [<Optional;DefaultParameterValue(null)>] ?Bar        : IndicatorBar,
+            [<Optional;DefaultParameterValue(null)>] ?BGColor    : Color,
+            [<Optional;DefaultParameterValue(null)>] ?BorderColor: Color,
+            [<Optional;DefaultParameterValue(null)>] ?BorderWidth: int,
+            [<Optional;DefaultParameterValue(null)>] ?Shape      : StyleParam.IndicatorGaugeShape,
+            [<Optional;DefaultParameterValue(null)>] ?Steps      : IndicatorSteps,
+            [<Optional;DefaultParameterValue(null)>] ?Threshold  : IndicatorThreshold
+        ) =
+            (fun (indicatorGauge: IndicatorGauge) -> 
+
+                Axis       |> DynObj.setValueOpt indicatorGauge "axis"
+                Bar        |> DynObj.setValueOpt indicatorGauge "bar"
+                BGColor    |> DynObj.setValueOpt indicatorGauge "bgcolor"
+                BorderColor|> DynObj.setValueOpt indicatorGauge "bordercolor"
+                BorderWidth|> DynObj.setValueOpt indicatorGauge "borderwidth"
+                Shape      |> DynObj.setValueOptBy indicatorGauge "shape" StyleParam.IndicatorGaugeShape.convert
+                Steps      |> DynObj.setValueOpt indicatorGauge "steps"
+                Threshold  |> DynObj.setValueOpt indicatorGauge "threshold  "
+
+                indicatorGauge
+            )

--- a/src/Plotly.NET/Traces/TraceDomain.fs
+++ b/src/Plotly.NET/Traces/TraceDomain.fs
@@ -326,3 +326,46 @@ type TraceDomainStyle() =
                 trace
             ) 
 
+    static member Indicator
+        (
+            [<Optional;DefaultParameterValue(null)>] ?Name              : string,
+            [<Optional;DefaultParameterValue(null)>] ?Title             : string,
+            [<Optional;DefaultParameterValue(null)>] ?Visible           : StyleParam.Visible,
+            [<Optional;DefaultParameterValue(null)>] ?ShowLegend        : bool,
+            [<Optional;DefaultParameterValue(null)>] ?LegendRank        : int,
+            [<Optional;DefaultParameterValue(null)>] ?LegendGroup       : string,
+            [<Optional;DefaultParameterValue(null)>] ?LegendGroupTitle  : Title,
+            [<Optional;DefaultParameterValue(null)>] ?Mode              : StyleParam.IndicatorMode,
+            [<Optional;DefaultParameterValue(null)>] ?Ids               : seq<#IConvertible>,
+            [<Optional;DefaultParameterValue(null)>] ?Value             : #IConvertible,
+            [<Optional;DefaultParameterValue(null)>] ?Meta              : string,
+            [<Optional;DefaultParameterValue(null)>] ?CustomData        : seq<#IConvertible>,
+            [<Optional;DefaultParameterValue(null)>] ?Domain            : Domain,
+            [<Optional;DefaultParameterValue(null)>] ?Align             : StyleParam.IndicatorAlignment,
+            [<Optional;DefaultParameterValue(null)>] ?Delta             : IndicatorDelta,
+            [<Optional;DefaultParameterValue(null)>] ?Number            : IndicatorNumber,
+            [<Optional;DefaultParameterValue(null)>] ?Gauge             : IndicatorGauge,
+            [<Optional;DefaultParameterValue(null)>] ?UIRevision        : string
+        ) =
+            fun (trace: #Trace) ->                  
+                
+                Name              |> DynObj.setValueOpt trace "name"
+                Title             |> DynObj.setValueOpt trace "title" 
+                Visible           |> DynObj.setValueOptBy trace "visible" StyleParam.Visible.convert
+                ShowLegend        |> DynObj.setValueOpt trace "showlegend"
+                LegendRank        |> DynObj.setValueOpt trace "legendrank"
+                LegendGroup       |> DynObj.setValueOpt trace "legendgroup"
+                LegendGroupTitle  |> DynObj.setValueOpt trace "legendgrouptitle"
+                Mode              |> DynObj.setValueOptBy trace "mode" StyleParam.IndicatorMode.convert
+                Ids               |> DynObj.setValueOpt trace "ids"
+                Value             |> DynObj.setValueOpt trace "value"
+                Meta              |> DynObj.setValueOpt trace "meta"
+                CustomData        |> DynObj.setValueOpt trace "customdata"
+                Domain            |> DynObj.setValueOpt trace "domain"
+                Align             |> DynObj.setValueOptBy trace "align" StyleParam.IndicatorAlignment.convert
+                Delta             |> DynObj.setValueOpt trace "delta"
+                Number            |> DynObj.setValueOpt trace "number"
+                Gauge             |> DynObj.setValueOpt trace "gauge"
+                UIRevision        |> DynObj.setValueOpt trace "uirevision"
+
+                trace

--- a/tests/Plotly.NET.Tests/HtmlCodegen/FinanceCharts.fs
+++ b/tests/Plotly.NET.Tests/HtmlCodegen/FinanceCharts.fs
@@ -99,3 +99,49 @@ let ``Funnel area charts`` =
             emptyLayout funnelArea
         );
     ]
+
+
+
+let indicators =
+    [
+        ChartDomain.Chart.Indicator(
+            200., StyleParam.IndicatorMode.NumberDeltaGauge,
+            Delta   = IndicatorDelta.init(Reference=160),
+            Range   = StyleParam.Range.MinMax(0., 250.),
+            Domain  = Domain.init(Row = 0, Column = 0)
+        )
+        Chart.Indicator(
+            120., StyleParam.IndicatorMode.NumberDeltaGauge,
+            DeltaReference = 90.,
+            Range = StyleParam.Range.MinMax(-200., 200.),
+            GaugeShape = StyleParam.IndicatorGaugeShape.Bullet,
+            ShowGaugeAxis = false,
+            Domain  = Domain.init(Row = 0, Column = 1)
+        )
+        Chart.Indicator(
+            300., StyleParam.IndicatorMode.NumberDelta,
+            DeltaReference = 90.,
+            Domain  = Domain.init(Row = 1, Column = 0)
+        )        
+        Chart.Indicator(
+            40., StyleParam.IndicatorMode.Delta,
+            DeltaReference = 90.,
+            Domain  = Domain.init(Row = 1, Column = 1)
+        )
+    ]
+    |> Chart.combine
+    |> Chart.withLayoutGridStyle(Rows = 2, Columns = 2)
+
+
+[<Tests>]
+let ``Indicator charts`` =
+    testList "FinanceCharts.Funnel area charts" [
+        testCase "Indicator data" ( fun () ->
+            """var data = [{"type":"indicator","mode":"number+delta+gauge","value":200.0,"domain":{"row":0,"column":0},"delta":{"reference":160},"gauge":{"axis":{"range":[0.0,250.0]}}},{"type":"indicator","mode":"number+delta+gauge","value":120.0,"domain":{"row":0,"column":1},"delta":{"reference":90.0},"gauge":{"axis":{"visible":false,"range":[-200.0,200.0]},"shape":"bullet"}},{"type":"indicator","mode":"number+delta","value":300.0,"domain":{"row":1,"column":0},"delta":{"reference":90.0},"gauge":{"axis":{}}},{"type":"indicator","mode":"delta","value":40.0,"domain":{"row":1,"column":1},"delta":{"reference":90.0},"gauge":{"axis":{}}}];"""
+            |> chartGeneratedContains funnelArea
+        );
+        testCase "Indicator layout" ( fun () ->
+            """var layout = {"grid":{"rows":2,"columns":2}};"""
+            |> chartGeneratedContains funnelArea
+        );
+    ]

--- a/tests/Plotly.NET.Tests/HtmlCodegen/FinanceCharts.fs
+++ b/tests/Plotly.NET.Tests/HtmlCodegen/FinanceCharts.fs
@@ -111,15 +111,15 @@ let indicators =
             Domain  = Domain.init(Row = 0, Column = 0)
         )
         Chart.Indicator(
-            120., StyleParam.IndicatorMode.NumberDeltaGauge,
-            DeltaReference = 90.,
+            120, StyleParam.IndicatorMode.NumberDeltaGauge,
+            DeltaReference = 90,
             Range = StyleParam.Range.MinMax(-200., 200.),
             GaugeShape = StyleParam.IndicatorGaugeShape.Bullet,
             ShowGaugeAxis = false,
             Domain  = Domain.init(Row = 0, Column = 1)
         )
         Chart.Indicator(
-            300., StyleParam.IndicatorMode.NumberDelta,
+            "300", StyleParam.IndicatorMode.NumberDelta,
             DeltaReference = 90.,
             Domain  = Domain.init(Row = 1, Column = 0)
         )        
@@ -135,13 +135,13 @@ let indicators =
 
 [<Tests>]
 let ``Indicator charts`` =
-    testList "FinanceCharts.Funnel area charts" [
+    testList "Indicator.Indicator charts" [
         testCase "Indicator data" ( fun () ->
             """var data = [{"type":"indicator","mode":"number+delta+gauge","value":200.0,"domain":{"row":0,"column":0},"delta":{"reference":160},"gauge":{"axis":{"range":[0.0,250.0]}}},{"type":"indicator","mode":"number+delta+gauge","value":120.0,"domain":{"row":0,"column":1},"delta":{"reference":90.0},"gauge":{"axis":{"visible":false,"range":[-200.0,200.0]},"shape":"bullet"}},{"type":"indicator","mode":"number+delta","value":300.0,"domain":{"row":1,"column":0},"delta":{"reference":90.0},"gauge":{"axis":{}}},{"type":"indicator","mode":"delta","value":40.0,"domain":{"row":1,"column":1},"delta":{"reference":90.0},"gauge":{"axis":{}}}];"""
-            |> chartGeneratedContains funnelArea
+            |> chartGeneratedContains indicators
         );
         testCase "Indicator layout" ( fun () ->
             """var layout = {"grid":{"rows":2,"columns":2}};"""
-            |> chartGeneratedContains funnelArea
+            |> chartGeneratedContains indicators
         );
     ]

--- a/tests/Plotly.NET.Tests/HtmlCodegen/FinanceCharts.fs
+++ b/tests/Plotly.NET.Tests/HtmlCodegen/FinanceCharts.fs
@@ -135,9 +135,9 @@ let indicators =
 
 [<Tests>]
 let ``Indicator charts`` =
-    testList "Indicator.Indicator charts" [
+    testList "FinanceCharts.Indicator charts" [
         testCase "Indicator data" ( fun () ->
-            """var data = [{"type":"indicator","mode":"number+delta+gauge","value":200.0,"domain":{"row":0,"column":0},"delta":{"reference":160},"gauge":{"axis":{"range":[0.0,250.0]}}},{"type":"indicator","mode":"number+delta+gauge","value":120.0,"domain":{"row":0,"column":1},"delta":{"reference":90.0},"gauge":{"axis":{"visible":false,"range":[-200.0,200.0]},"shape":"bullet"}},{"type":"indicator","mode":"number+delta","value":300.0,"domain":{"row":1,"column":0},"delta":{"reference":90.0},"gauge":{"axis":{}}},{"type":"indicator","mode":"delta","value":40.0,"domain":{"row":1,"column":1},"delta":{"reference":90.0},"gauge":{"axis":{}}}];"""
+            """var data = [{"type":"indicator","mode":"number+delta+gauge","value":200.0,"domain":{"row":0,"column":0},"delta":{"reference":160},"gauge":{"axis":{"range":[0.0,250.0]}}},{"type":"indicator","mode":"number+delta+gauge","value":120,"domain":{"row":0,"column":1},"delta":{"reference":90},"gauge":{"axis":{"visible":false,"range":[-200.0,200.0]},"shape":"bullet"}},{"type":"indicator","mode":"number+delta","value":"300","domain":{"row":1,"column":0},"delta":{"reference":90.0},"gauge":{"axis":{}}},{"type":"indicator","mode":"delta","value":40.0,"domain":{"row":1,"column":1},"delta":{"reference":90.0},"gauge":{"axis":{}}}];"""
             |> chartGeneratedContains indicators
         );
         testCase "Indicator layout" ( fun () ->


### PR DESCRIPTION
This PR adds full Indicator trace support.

- [x] TraceDomainStyle/Chart.Indicator
- [x] Related TraceObjects and StyleParams
- [x] docs
- [x] tests
- [x] take care of the strange compiler error

closes #206 