### PR TITLE
Improve Chart.Grid

### DIFF
--- a/docs/01_2_multiple-charts.fsx
+++ b/docs/01_2_multiple-charts.fsx
@@ -237,3 +237,65 @@ singleStack
 (***hide***)
 singleStack |> GenericChart.toChartHTML
 (***include-it-raw***)
+
+(**
+### Using subplots of different trace types in a grid
+
+Chart.Grid does some internal magic to make sure that all trace types get their grid cell according to plotly.js's inner logic. 
+
+The only thing you have to consider is, that when you are using nested combined charts, that these have to have the same trace type.
+
+Otherwise, you can freely combine all charts with Chart.Grid:
+
+*)
+open Plotly.NET.LayoutObjects
+
+let multipleTraceTypesGrid =
+    [
+        Chart.Point([1,2; 2,3])
+        Chart.PointTernary([1,2,3; 2,3,4])
+        Chart.Heatmap([[1; 2];[3; 4]], Showscale=false)
+        Chart.Point3d([1,3,2])
+        Chart.PointMapbox([1,2]) |> Chart.withMapbox(Mapbox.init(Style = StyleParam.MapboxStyle.OpenStreetMap))
+        [
+            // you can use nested combined charts, but they have to have the same trace type (Cartesian2D in this case)
+            let y =  [2.; 1.5; 5.; 1.5; 2.; 2.5; 2.1; 2.5; 1.5; 1.;2.; 1.5; 5.; 1.5; 3.; 2.5; 2.5; 1.5; 3.5; 1.]
+            Chart.BoxPlot("y" ,y,Name="bin1",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
+            Chart.BoxPlot("y'",y,Name="bin2",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
+        ]
+        |> Chart.combine
+    ]
+    |> Chart.Grid(2,3)
+    |> Chart.withSize(1000,1000)
+
+(*** condition: ipynb ***)
+#if IPYNB
+multipleTraceTypesGrid
+#endif // IPYNB
+
+(***hide***)
+multipleTraceTypesGrid |> GenericChart.toChartHTML
+(***include-it-raw***)
+    
+(**
+If you are not sure if traceTypes are compatible, look at the `TraceIDs`:
+*)
+
+let pointType = Chart.Point([1,2]) |> GenericChart.getTraceID
+(***include-it***)
+
+[
+     Chart.Point([1,2])
+     Chart.PointTernary([1,2,3])
+]
+|> Chart.combine
+|> GenericChart.getTraceID
+(***include-it***)
+
+[
+     Chart.Point([1,2])
+     Chart.PointTernary([1,2,3])
+]
+|> Chart.combine
+|> GenericChart.getTraceIDs
+(***include-it***)

--- a/src/Plotly.NET/ChartAPI/GenericChart.fs
+++ b/src/Plotly.NET/ChartAPI/GenericChart.fs
@@ -409,4 +409,14 @@ module GenericChart =
         | Chart (trace, layout, config, displayOpts)       -> Chart (trace, layout, config, f displayOpts)
         | MultiChart (traces, layout, config, displayOpts) -> MultiChart (traces,layout,config, f displayOpts)
 
-
+    /// returns a single TraceID (when all traces of the charts are of the same type), or traceID.Multi if the chart contains traces of multiple different types
+    let getTraceID gChart =
+        match gChart with
+        | Chart (trace, _, _, _)       -> TraceID.ofTrace trace
+        | MultiChart (traces, layout, config, displayOpts) -> TraceID.ofTraces traces
+        
+    /// returns a list of TraceIDs representing the types of all traces contained in the chart.
+    let getTraceIDs gChart =
+        match gChart with
+        | Chart (trace, _, _, _)       -> [TraceID.ofTrace trace]
+        | MultiChart (traces, _, _, _) -> traces |> List.map TraceID.ofTrace

--- a/src/Plotly.NET/Playground.fsx
+++ b/src/Plotly.NET/Playground.fsx
@@ -636,3 +636,20 @@ let heatmap2=
 |> Chart.Grid(1,2)
 |> Chart.withColorAxis(ColorAxis.init(AutoColorScale=true))
 |> Chart.show
+
+[
+    Chart.Point([1,2; 2,3])
+    Chart.PointTernary([1,2,3; 2,3,4])
+    Chart.Heatmap([[1; 2];[3; 4]], Showscale=false)
+    Chart.Point3d([1,3,2])
+    Chart.PointMapbox([1,2]) |> Chart.withMapbox(Mapbox.init(Style = StyleParam.MapboxStyle.OpenStreetMap))
+    [
+        let y =  [2.; 1.5; 5.; 1.5; 2.; 2.5; 2.1; 2.5; 1.5; 1.;2.; 1.5; 5.; 1.5; 3.; 2.5; 2.5; 1.5; 3.5; 1.]
+        Chart.BoxPlot("y" ,y,Name="bin1",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
+        Chart.BoxPlot("y'",y,Name="bin2",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
+    ]
+    |> Chart.combine
+]
+|> Chart.Grid(2,3)
+|> Chart.withSize(1000,1000)
+|> Chart.show

--- a/src/Plotly.NET/Traces/Trace.fs
+++ b/src/Plotly.NET/Traces/Trace.fs
@@ -7,7 +7,7 @@ open System
 open System.Runtime.InteropServices
 
 /// Trace type inherits from dynamic object
-type Trace (traceTypeName) =
+type Trace (traceTypeName:string) =
     inherit DynamicObj ()
     //interface ITrace with
         // Implictit ITrace
@@ -202,8 +202,13 @@ type TraceStyle() =
 
             )
 
-
-
+    /// Sets the given color axis anchor on a Trace object. (determines which colorscale it uses)
+    static member setColorAxisAnchor (?ColorAxisId: int) =
+        let id = ColorAxisId |> Option.map StyleParam.SubPlotId.ColorAxis 
+        (fun (trace:('T :> Trace)) ->
+            id |> DynObj.setValueOptBy trace "coloraxis" StyleParam.SubPlotId.convert
+            trace
+        )
 
     /// Sets the given domain on a Trace object.
     static member SetDomain

--- a/src/Plotly.NET/Traces/TraceCarpet.fs
+++ b/src/Plotly.NET/Traces/TraceCarpet.fs
@@ -24,6 +24,20 @@ type TraceCarpet(traceTypeName) =
 
 type TraceCarpetStyle() =
 
+    /// Sets the given axis anchor id(s) on a Trace object.
+    static member SetAxisAnchor
+        (
+            [<Optional;DefaultParameterValue(null)>] ?X:StyleParam.LinearAxisId,
+            [<Optional;DefaultParameterValue(null)>] ?Y:StyleParam.LinearAxisId
+        ) =  
+            (fun (trace:TraceCarpet) ->
+
+                X     |> DynObj.setValueOptBy trace "xaxis" StyleParam.LinearAxisId.toString
+                Y     |> DynObj.setValueOptBy trace "yaxis" StyleParam.LinearAxisId.toString
+                
+                trace
+            )
+
     static member SetCarpet
         (
             [<Optional;DefaultParameterValue(null)>] ?CarpetId:StyleParam.SubPlotId

--- a/src/Plotly.NET/Traces/TraceID.fs
+++ b/src/Plotly.NET/Traces/TraceID.fs
@@ -12,7 +12,7 @@ type TraceID =
     | Cartesian3D 
     | Polar 
     | Geo 
-    | Mapbox 
+    | Mapbox
     | Ternary 
     | Carpet 
     | Domain 
@@ -28,4 +28,11 @@ type TraceID =
         | :? TraceTernary -> TraceID.Ternary    
         | :? TraceCarpet  -> TraceID.Carpet     
         | :? TraceDomain  -> TraceID.Domain     
-        | _ as unknownTraceType -> failwith $"unknown trace type {unknownTraceType.GetType()}"
+        | _ as unknownTraceType -> failwith $"cannot get trace id for type {unknownTraceType.GetType()}"
+
+    static member ofTraces (t:seq<Trace>) : TraceID =
+        let traceIds = t |> Seq.map TraceID.ofTrace |> Seq.distinct |> Array.ofSeq
+        match traceIds with
+        | [|sameTraceID|]   -> sameTraceID
+        | [||]              -> TraceID.Domain
+        | _                 -> TraceID.Multi

--- a/tests/Plotly.NET.Tests/HtmlCodegen/ChartLayout.fs
+++ b/tests/Plotly.NET.Tests/HtmlCodegen/ChartLayout.fs
@@ -157,7 +157,44 @@ let singleStackChart =
     |> Chart.withLayoutGridStyle(XSide=StyleParam.LayoutGridXSide.Bottom,YGap= 0.1)
     |> Chart.withTitle("Hi i am the new SingleStackChart")
     |> Chart.withXAxisStyle("im the shared xAxis")
-    
+
+let multiTraceGrid = 
+    [
+        Chart.Point([1,2; 2,3])
+        Chart.PointTernary([1,2,3; 2,3,4])
+        Chart.Heatmap([[1; 2];[3; 4]], Showscale=false)
+        Chart.Point3d([1,3,2])
+        Chart.PointMapbox([1,2]) |> Chart.withMapbox(Mapbox.init(Style = StyleParam.MapboxStyle.OpenStreetMap))
+        [
+            // you can use nested combined charts, but they have to have the same trace type (Cartesian2D in this case)
+            let y =  [2.; 1.5; 5.; 1.5; 2.; 2.5; 2.1; 2.5; 1.5; 1.;2.; 1.5; 5.; 1.5; 3.; 2.5; 2.5; 1.5; 3.5; 1.]
+            Chart.BoxPlot("y" ,y,Name="bin1",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
+            Chart.BoxPlot("y'",y,Name="bin2",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
+        ]
+        |> Chart.combine
+    ]
+    |> Chart.Grid(2,3)
+    |> Chart.withSize(1000,1000)
+
+
+let multiTraceSingleStack = 
+    [
+        Chart.Point([1,2; 2,3])
+        Chart.PointTernary([1,2,3; 2,3,4])
+        Chart.Heatmap([[1; 2];[3; 4]], Showscale=false)
+        Chart.Point3d([1,3,2])
+        Chart.PointMapbox([1,2]) |> Chart.withMapbox(Mapbox.init(Style = StyleParam.MapboxStyle.OpenStreetMap))
+        [
+            // you can use nested combined charts, but they have to have the same trace type (Cartesian2D in this case)
+            let y =  [2.; 1.5; 5.; 1.5; 2.; 2.5; 2.1; 2.5; 1.5; 1.;2.; 1.5; 5.; 1.5; 3.; 2.5; 2.5; 1.5; 3.5; 1.]
+            Chart.BoxPlot("y" ,y,Name="bin1",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
+            Chart.BoxPlot("y'",y,Name="bin2",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
+        ]
+        |> Chart.combine
+    ]
+    |> Chart.SingleStack()
+    |> Chart.withSize(1000,1000)
+
 [<Tests>]
 let ``Multicharts and subplots`` =
     testList "ChartLayout.Multicharts and subplots" [
@@ -172,6 +209,14 @@ let ``Multicharts and subplots`` =
         testCase "Subplot grids layout" ( fun () ->
             "var layout = {\"xaxis\":{\"title\":{\"text\":\"x1\"}},\"yaxis\":{\"title\":{\"text\":\"y1\"}},\"xaxis2\":{\"title\":{\"text\":\"x2\"}},\"yaxis2\":{\"title\":{\"text\":\"y2\"}},\"xaxis3\":{\"title\":{\"text\":\"x3\"}},\"yaxis3\":{\"title\":{\"text\":\"y3\"}},\"xaxis4\":{\"title\":{\"text\":\"x4\"}},\"yaxis4\":{\"title\":{\"text\":\"y4\"}},\"grid\":{\"rows\":2,\"columns\":2,\"pattern\":\"independent\"}};"
             |> chartGeneratedContains subPlotChart
+        );        
+        testCase "MultiTrace Subplot grid data" ( fun () ->
+            """var data = [{"type":"scatter","mode":"markers","x":[1,2],"y":[2,3],"marker":{},"xaxis":"x","yaxis":"y"},{"type":"scatterternary","mode":"markers","a":[1,2],"b":[2,3],"c":[3,4],"marker":{},"subplot":"ternary2"},{"type":"heatmap","z":[[1,2],[3,4]],"showscale":false,"xaxis":"x3","yaxis":"y3"},{"type":"scatter3d","mode":"markers","x":[1],"y":[3],"z":[2],"line":{},"marker":{},"scene":"scene4"},{"type":"scattermapbox","mode":"markers","lon":[1],"lat":[2],"line":{},"marker":{},"subplot":"mapbox5"},{"type":"box","y":[2.0,1.5,5.0,1.5,2.0,2.5,2.1,2.5,1.5,1.0,2.0,1.5,5.0,1.5,3.0,2.5,2.5,1.5,3.5,1.0],"x":"y","boxpoints":"all","jitter":0.1,"name":"bin1","marker":{},"xaxis":"x6","yaxis":"y6"},{"type":"box","y":[2.0,1.5,5.0,1.5,2.0,2.5,2.1,2.5,1.5,1.0,2.0,1.5,5.0,1.5,3.0,2.5,2.5,1.5,3.5,1.0],"x":"y'","boxpoints":"all","jitter":0.1,"name":"bin2","marker":{},"xaxis":"x6","yaxis":"y6"}];"""
+            |> chartGeneratedContains multiTraceGrid
+        );
+        testCase "MultiTrace Subplot grid layout" ( fun () ->
+            """var layout = {"xaxis":{},"yaxis":{},"ternary2":{"domain":{"row":0,"column":1}},"xaxis3":{},"yaxis3":{},"scene4":{"domain":{"row":1,"column":0}},"mapbox":{"style":"open-street-map","domain":{"row":1,"column":1}},"mapbox5":{"style":"open-street-map","domain":{"row":1,"column":1}},"xaxis6":{},"yaxis6":{},"grid":{"rows":2,"columns":3,"pattern":"independent"},"width":1000,"height":1000};"""
+            |> chartGeneratedContains multiTraceGrid
         );
         testCase "Single Stack data" ( fun () -> 
             """var data = [{"type":"scatter","mode":"markers","x":[1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0],"y":[2.0,1.5,5.0,1.5,3.0,2.5,2.5,1.5,3.5,1.0],"marker":{},"xaxis":"x","yaxis":"y"},{"type":"scatter","mode":"lines","x":[1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0],"y":[2.0,1.5,5.0,1.5,3.0,2.5,2.5,1.5,3.5,1.0],"line":{},"marker":{},"xaxis":"x","yaxis":"y2"},{"type":"scatter","mode":"lines","x":[1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0],"y":[2.0,1.5,5.0,1.5,3.0,2.5,2.5,1.5,3.5,1.0],"line":{"shape":"spline"},"marker":{},"xaxis":"x","yaxis":"y3"}];"""
@@ -180,6 +225,15 @@ let ``Multicharts and subplots`` =
         testCase "Single Stack layout" ( fun () -> 
             "var layout = {\"yaxis\":{\"title\":{\"text\":\"This title must\"}},\"xaxis\":{\"title\":{\"text\":\"im the shared xAxis\"}},\"xaxis2\":{},\"yaxis2\":{\"title\":{\"text\":\"be set on the\"},\"zeroline\":false},\"xaxis3\":{},\"yaxis3\":{\"title\":{\"text\":\"respective subplots\"},\"zeroline\":false},\"grid\":{\"rows\":3,\"columns\":1,\"pattern\":\"coupled\",\"ygap\":0.1,\"xside\":\"bottom\"},\"title\":{\"text\":\"Hi i am the new SingleStackChart\"}};"
             |> chartGeneratedContains singleStackChart
+        );        
+        
+        testCase "MultiTrace Single Stack data" ( fun () -> 
+            """var data = [{"type":"scatter","mode":"markers","x":[1,2],"y":[2,3],"marker":{},"xaxis":"x","yaxis":"y"},{"type":"scatterternary","mode":"markers","a":[1,2],"b":[2,3],"c":[3,4],"marker":{},"subplot":"ternary2"},{"type":"heatmap","z":[[1,2],[3,4]],"showscale":false,"xaxis":"x3","yaxis":"y3"},{"type":"scatter3d","mode":"markers","x":[1],"y":[3],"z":[2],"line":{},"marker":{},"scene":"scene4"},{"type":"scattermapbox","mode":"markers","lon":[1],"lat":[2],"line":{},"marker":{},"subplot":"mapbox5"},{"type":"box","y":[2.0,1.5,5.0,1.5,2.0,2.5,2.1,2.5,1.5,1.0,2.0,1.5,5.0,1.5,3.0,2.5,2.5,1.5,3.5,1.0],"x":"y","boxpoints":"all","jitter":0.1,"name":"bin1","marker":{},"xaxis":"x6","yaxis":"y6"},{"type":"box","y":[2.0,1.5,5.0,1.5,2.0,2.5,2.1,2.5,1.5,1.0,2.0,1.5,5.0,1.5,3.0,2.5,2.5,1.5,3.5,1.0],"x":"y'","boxpoints":"all","jitter":0.1,"name":"bin2","marker":{},"xaxis":"x6","yaxis":"y6"}];"""
+            |> chartGeneratedContains multiTraceSingleStack
+        );
+        testCase "MultiTrace Single Stack layout" ( fun () -> 
+            """var layout = {"xaxis":{},"yaxis":{},"ternary2":{"domain":{"row":1,"column":0}},"xaxis3":{},"yaxis3":{},"scene4":{"domain":{"row":3,"column":0}},"mapbox":{"style":"open-street-map","domain":{"row":4,"column":0}},"mapbox5":{"style":"open-street-map","domain":{"row":4,"column":0}},"xaxis6":{},"yaxis6":{},"grid":{"rows":6,"columns":1,"pattern":"independent"},"width":1000,"height":1000};"""
+            |> chartGeneratedContains multiTraceSingleStack
         );
     ]
 

--- a/tests/Plotly.NET.Tests/Plotly.NET.Tests.fsproj
+++ b/tests/Plotly.NET.Tests/Plotly.NET.Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="TestUtils.fs" />
     <Compile Include="CommonAbstractions\Colors.fs" />
     <Compile Include="LayoutObjects\LinearAxis.fs" />
+    <Compile Include="Traces\TraceID.fs" />
     <Compile Include="HtmlCodegen\SimpleTests.fs" />
     <Compile Include="HtmlCodegen\ChartLayout.fs" />
     <Compile Include="HtmlCodegen\SimpleCharts.fs" />

--- a/tests/Plotly.NET.Tests/Traces/TraceID.fs
+++ b/tests/Plotly.NET.Tests/Traces/TraceID.fs
@@ -1,0 +1,53 @@
+﻿module Tests.LayoutObjects.TraceID
+
+open Expecto
+open Plotly.NET
+open Plotly.NET.LayoutObjects
+open Plotly.NET.TraceObjects
+open Plotly.NET.GenericChart
+
+let allTraceTypesChart =
+    [
+        Chart.Point([])
+        Chart.Point3d([])
+        Chart.PointPolar([])
+        Chart.ChoroplethMap([],[])
+        Chart.ChoroplethMapbox([],[],obj)
+        Chart.PointTernary([1,2,3])
+        Chart.PointCarpet([], "")
+        Chart.Pie([2])
+        [
+            Chart.PointCarpet([], "")
+            Chart.Pie([2])
+        ]
+        |> Chart.combine
+    ]
+    |> Chart.combine
+
+[<Tests>]
+let ``TraceID tests`` =
+    testList "Traces.TraceID" [
+        testCase "extract single TraceID from Chart" (fun _ ->
+            Expect.equal
+                (allTraceTypesChart |> GenericChart.getTraceID)
+                TraceID.Multi
+                "GenericChart.getTraceID did not return the correct TraceID for all traces"
+            )
+        testCase "extract all TraceIDS from Chart" (fun _ ->
+            Expect.equal
+                (allTraceTypesChart |> GenericChart.getTraceIDs)
+                [
+                    TraceID.Cartesian2D
+                    TraceID.Cartesian3D
+                    TraceID.Polar
+                    TraceID.Geo
+                    TraceID.Mapbox
+                    TraceID.Ternary
+                    TraceID.Carpet
+                    TraceID.Domain                    
+                    TraceID.Carpet
+                    TraceID.Domain
+                ]
+                "GenericChart.getTraceIDs did not return the correct TraceIDs for all traces."
+        )
+    ]


### PR DESCRIPTION
This PR drastically improves Chart.Grid, which previously only worked with 2D cartesian traces.

- [x] Make `Chart.Grid` work for all trace types
- [x] adapt docs
- [x] add tests

It now works with **ALL** trace types as well as nested composite charts as long as they have the same trace type. here is an example:

```fsharp
[
    Chart.Point([1,2; 2,3])
    Chart.PointTernary([1,2,3; 2,3,4])
    Chart.Heatmap([[1; 2];[3; 4]], Showscale=false)
    Chart.Point3d([1,3,2])
    Chart.PointMapbox([1,2]) |> Chart.withMapbox(Mapbox.init(Style = StyleParam.MapboxStyle.OpenStreetMap))
    [
        let y =  [2.; 1.5; 5.; 1.5; 2.; 2.5; 2.1; 2.5; 1.5; 1.;2.; 1.5; 5.; 1.5; 3.; 2.5; 2.5; 1.5; 3.5; 1.]
        Chart.BoxPlot("y" ,y,Name="bin1",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
        Chart.BoxPlot("y'",y,Name="bin2",Jitter=0.1,Boxpoints=StyleParam.Boxpoints.All);
    ]
    |> Chart.combine
]
|> Chart.Grid(2,3)
|> Chart.withSize(1000,1000)
|> Chart.show
```

![image](https://user-images.githubusercontent.com/21338071/135413399-ef746bc8-73e5-4b5f-a180-4e3286a002b9.png)

closes #163 
closes #149 