### PR TITLE
Update PuppeteerSharp to 6.0

### DIFF
--- a/src/Plotly.NET.ImageExport/Plotly.NET.ImageExport.fsproj
+++ b/src/Plotly.NET.ImageExport/Plotly.NET.ImageExport.fsproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="DynamicObj" Version="0.2.0" />
-    <PackageReference Include="PuppeteerSharp" Version="4.0.0" />
+    <PackageReference Include="PuppeteerSharp" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
On top of getting a more recent version, it removes multiple transitive dependencies that weren't needed, and previously required in order to use Plotly.NET.ImageExport.