### PR TITLE
Correct Json mapping for Angular and Radial Axis Styles

### DIFF
--- a/src/Plotly.NET/Layout/ObjectAbstractions/Polar/AngularAxis.fs
+++ b/src/Plotly.NET/Layout/ObjectAbstractions/Polar/AngularAxis.fs
@@ -244,9 +244,9 @@ type AngularAxis() =
             CategoryOrder |> DynObj.setValueOptBy angularAxis "categoryorder" StyleParam.CategoryOrder.convert
             CategoryArray |> DynObj.setValueOpt angularAxis "categoryarray"
             ThetaUnit |> DynObj.setValueOpt angularAxis "thetaunit"
-            Period |> DynObj.setValueOpt angularAxis "Period"
-            Direction |> DynObj.setValueOpt angularAxis "Direction"
-            Rotation |> DynObj.setValueOpt angularAxis "Rotation"
+            Period |> DynObj.setValueOpt angularAxis "period"
+            Direction |> DynObj.setValueOptBy angularAxis "direction" StyleParam.Direction.convert
+            Rotation |> DynObj.setValueOpt angularAxis "rotation"
             HoverFormat |> DynObj.setValueOpt angularAxis "hoverformat"
             UIRevision |> DynObj.setValueOpt angularAxis "uirevision"
             Color |> DynObj.setValueOpt angularAxis "color"

--- a/src/Plotly.NET/Layout/ObjectAbstractions/Polar/AngularAxis.fs
+++ b/src/Plotly.NET/Layout/ObjectAbstractions/Polar/AngularAxis.fs
@@ -260,8 +260,8 @@ type AngularAxis() =
             NTicks |> DynObj.setValueOpt angularAxis "nticks"
             Tick0 |> DynObj.setValueOpt angularAxis "tick0"
             DTick |> DynObj.setValueOpt angularAxis "dtick"
-            TickVals |> DynObj.setValueOpt angularAxis "tickVals"
-            TickText |> DynObj.setValueOpt angularAxis "tickText"
+            TickVals |> DynObj.setValueOpt angularAxis "tickvals"
+            TickText |> DynObj.setValueOpt angularAxis "ticktext"
             Ticks |> DynObj.setValueOptBy angularAxis "ticks" StyleParam.TickOptions.convert
             TickLen |> DynObj.setValueOpt angularAxis "ticklen"
             TickWidth |> DynObj.setValueOpt angularAxis "tickwidth"
@@ -277,7 +277,7 @@ type AngularAxis() =
             SeparateThousands |> DynObj.setValueOpt angularAxis "separatethousands"
             TickFont |> DynObj.setValueOpt angularAxis "tickfont"
             TickAngle |> DynObj.setValueOpt angularAxis "tickangle"
-            TickFormat |> DynObj.setValueOpt angularAxis "tickFormat"
+            TickFormat |> DynObj.setValueOpt angularAxis "tickformat"
             TickFormatStops |> DynObj.setValueOpt angularAxis "tickformatstops"
             Layer |> DynObj.setValueOptBy angularAxis "layer" StyleParam.Layer.convert
 

--- a/src/Plotly.NET/Layout/ObjectAbstractions/Polar/AngularAxis.fs
+++ b/src/Plotly.NET/Layout/ObjectAbstractions/Polar/AngularAxis.fs
@@ -260,8 +260,8 @@ type AngularAxis() =
             NTicks |> DynObj.setValueOpt angularAxis "nticks"
             Tick0 |> DynObj.setValueOpt angularAxis "tick0"
             DTick |> DynObj.setValueOpt angularAxis "dtick"
-            TickVals |> DynObj.setValueOpt angularAxis "TickVals"
-            TickText |> DynObj.setValueOpt angularAxis "TickText"
+            TickVals |> DynObj.setValueOpt angularAxis "tickVals"
+            TickText |> DynObj.setValueOpt angularAxis "tickText"
             Ticks |> DynObj.setValueOptBy angularAxis "ticks" StyleParam.TickOptions.convert
             TickLen |> DynObj.setValueOpt angularAxis "ticklen"
             TickWidth |> DynObj.setValueOpt angularAxis "tickwidth"
@@ -277,7 +277,7 @@ type AngularAxis() =
             SeparateThousands |> DynObj.setValueOpt angularAxis "separatethousands"
             TickFont |> DynObj.setValueOpt angularAxis "tickfont"
             TickAngle |> DynObj.setValueOpt angularAxis "tickangle"
-            TickFormat |> DynObj.setValueOpt angularAxis "TickFormat"
+            TickFormat |> DynObj.setValueOpt angularAxis "tickFormat"
             TickFormatStops |> DynObj.setValueOpt angularAxis "tickformatstops"
             Layer |> DynObj.setValueOptBy angularAxis "layer" StyleParam.Layer.convert
 

--- a/src/Plotly.NET/Layout/ObjectAbstractions/Polar/RadialAxis.fs
+++ b/src/Plotly.NET/Layout/ObjectAbstractions/Polar/RadialAxis.fs
@@ -276,8 +276,8 @@ type RadialAxis() =
             NTicks |> DynObj.setValueOpt radialAxis "nticks"
             Tick0 |> DynObj.setValueOpt radialAxis "tick0"
             DTick |> DynObj.setValueOpt radialAxis "dtick"
-            TickVals |> DynObj.setValueOpt radialAxis "TickVals"
-            TickText |> DynObj.setValueOpt radialAxis "TickText"
+            TickVals |> DynObj.setValueOpt radialAxis "tickvals"
+            TickText |> DynObj.setValueOpt radialAxis "ticktext"
             Ticks |> DynObj.setValueOptBy radialAxis "ticks" StyleParam.TickOptions.convert
             TickLen |> DynObj.setValueOpt radialAxis "ticklen"
             TickWidth |> DynObj.setValueOpt radialAxis "tickwidth"
@@ -293,7 +293,7 @@ type RadialAxis() =
             SeparateThousands |> DynObj.setValueOpt radialAxis "separatethousands"
             TickFont |> DynObj.setValueOpt radialAxis "tickfont"
             TickAngle |> DynObj.setValueOpt radialAxis "tickangle"
-            TickFormat |> DynObj.setValueOpt radialAxis "TickFormat"
+            TickFormat |> DynObj.setValueOpt radialAxis "tickformat"
             TickFormatStops |> DynObj.setValueOpt radialAxis "tickformatstops"
             Layer |> DynObj.setValueOptBy radialAxis "layer" StyleParam.Layer.convert
             Calendar |> DynObj.setValueOptBy radialAxis "calendar" StyleParam.Calendar.convert


### PR DESCRIPTION
Corrects json representation of AngularAxis styles
- direction
  - uses setValueOptBy for Direction, to map the DU
- rotation 
- period
- tickVals
- tickFormat
- tickText

closes #251 
