### PR TITLE
add hovermode button to mode bar

### DIFF
--- a/src/Plotly.NET/CommonAbstractions/StyleParams.fs
+++ b/src/Plotly.NET/CommonAbstractions/StyleParams.fs
@@ -1824,6 +1824,7 @@ module StyleParam =
         | HoverClosestPie
         | ResetSankeyGroup
         | ToggleHover
+        | HoverMode
         | ResetViews
         | ToggleSpikelines
         | ResetViewMapbox
@@ -1867,6 +1868,7 @@ module StyleParam =
             | HoverClosestPie -> "hoverClosestPie"
             | ResetSankeyGroup -> "resetSankeyGroup"
             | ToggleHover -> "toggleHover"
+            | HoverMode -> "v1hovermode"
             | ResetViews -> "resetViews"
             | ToggleSpikelines -> "toggleSpikelines"
             | ResetViewMapbox -> "resetViewMapbox"


### PR DESCRIPTION
fixes #257

The addition enables the activation of the multi-hover button in the mode bar.


```
let multiview = 
    [
    Chart.Point([1,2; 2,3])
    Chart.Point([1,2; 2,3])
    ]
    |> Chart.combine
    |> Chart.withConfig(Config.init(ModeBarButtonsToAdd=[StyleParam.ModeBarButton.HoverMode]))
    |> Chart.show
```

![image](https://user-images.githubusercontent.com/28917670/150153045-7dac32f5-944a-486c-a39f-ed49196ba306.png)
