### PR TITLE
StaticImageExport: Allow to use a local browser, instead of BrowserFetcher 

### DIFF
--- a/src/Plotly.NET.ImageExport/PuppeteerSharpRenderer.fs
+++ b/src/Plotly.NET.ImageExport/PuppeteerSharpRenderer.fs
@@ -12,8 +12,10 @@ open DynamicObj
 module PuppeteerSharpRendererOptions =
 
     let mutable launchOptions = LaunchOptions()
-
     launchOptions.Timeout <- 60000
+
+    let mutable localBrowserExecutablePath = None
+
 
 type PuppeteerSharpRenderer() =
 
@@ -78,16 +80,25 @@ type PuppeteerSharpRenderer() =
     /// Initalizes headless browser
     let fetchAndLaunchBrowserAsync () =
         async {
-            use browserFetcher = new BrowserFetcher()
+            match PuppeteerSharpRendererOptions.localBrowserExecutablePath with
+            | None -> 
+                use browserFetcher = new BrowserFetcher()
 
-            let! revision = browserFetcher.DownloadAsync() |> Async.AwaitTask
+                let! revision = browserFetcher.DownloadAsync() |> Async.AwaitTask
 
-            let launchOptions =
-                PuppeteerSharpRendererOptions.launchOptions
+                let launchOptions =
+                    PuppeteerSharpRendererOptions.launchOptions
 
-            launchOptions.ExecutablePath <- revision.ExecutablePath
+                launchOptions.ExecutablePath <- revision.ExecutablePath
 
-            return! Puppeteer.LaunchAsync(launchOptions) |> Async.AwaitTask
+                return! Puppeteer.LaunchAsync(launchOptions) |> Async.AwaitTask
+            | Some p ->
+                let launchOptions =
+                    PuppeteerSharpRendererOptions.launchOptions
+                
+                launchOptions.ExecutablePath <- p
+                
+                return! Puppeteer.LaunchAsync(launchOptions) |> Async.AwaitTask
         }
 
     /// Initalizes headless browser


### PR DESCRIPTION
With the current implementation,  there is always the `BrowserFetcher` called when exporting an image.
This is a problem when the library is used e.g. in some environment with limited access to the Internet, because chromium is downloaded at least once.

I added an option to set a `localBrowserExecutablePath` in the `PuppeteerSharpRendererOptions`.
If that options set, `fetchAndLaunchBrowserAsync` uses that path. Otherwise it calls the `BrowserFetcher` and and does the already known stuff. 
