### PR TITLE
Delete Chart.show test code?

### DIFF
--- a/docs/00_6_multi-arguments.fsx
+++ b/docs/00_6_multi-arguments.fsx
@@ -107,8 +107,3 @@ bar2
 (***hide***)
 bar2 |> GenericChart.toChartHTML
 (***include-it-raw***)
-
-bar1
-|> Chart.show
-bar2
-|> Chart.show


### PR DESCRIPTION
I was building docs and I noticed these charts popping up. I think this is test code that wasn't deleted.