### PR TITLE
Fix closing div tag in Interactive Formatter

### DIFF
--- a/src/Plotly.NET.Interactive/Formatters.fs
+++ b/src/Plotly.NET.Interactive/Formatters.fs
@@ -10,7 +10,7 @@ module Formatters =
 <div>
     [CHART]
     [DESCRIPTION]
-</div    
+</div>    
 """
 
     /// Converts a GenericChart to it's HTML representation and embeds it in a div element, together with the chart description for display in notebook environments.


### PR DESCRIPTION
Hello!
This PR fixes a bug where the html generated by the formatter doesn't properly close the div tag.

This causes anything "after" a Plotly.NET chart not to work properly.

Request Review From:
@kMutagene 