### PR TITLE
Binder button fix

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -67,10 +67,10 @@ USER ${USER}
 RUN pip install nteract_on_jupyter
 
 # Install lastest build from master branch of Microsoft.DotNet.Interactive
-RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+#RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 
 #latest stable from nuget.org
-#RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://api.nuget.org/v3/index.json"
+RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://api.nuget.org/v3/index.json"
 
 ENV PATH="${PATH}:${HOME}/.dotnet/tools"
 RUN echo "$PATH"


### PR DESCRIPTION
The "Run in Binder" button from the main page is currently broken. I believe the problem can be traced to the Dockerfile used to build the Binder environment in the /docs folder, but I can't test this locally. I recommend installing the latest stable tool from Nuget (instead of the latest build) which should fix the problem. Better to have a working Binder environment than a broken one.