### PR TITLE
Add C# bindings for finance charts

### DIFF
--- a/src/Plotly.NET.CSharp/ChartAPI/Chart2D.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/Chart2D.cs
@@ -1037,6 +1037,70 @@ namespace Plotly.NET.CSharp
                     UseDefaults: UseDefaults.ToOption()
                 );
 
+        /// <summary>
+        /// Creates a candlestick chart.
+        ///
+        /// The candlestick is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The boxes represent the spread between the `open` and `close` values and the lines represent the spread between the `low` and `high` values Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red.
+        /// </summary>
+        /// <param name="open">Sets the open values.</param>
+        /// <param name="high">Sets the high values.</param>
+        /// <param name="low">Sets the low values.</param>
+        /// <param name="close">Sets the close values.</param>
+        /// <param name="x">Sets the x coordinates. If absent, linear coordinate will be generated.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover.</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the Opacity otf the trace.</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="Line">Sets the line of this trace.</param>
+        /// <param name="IncreasingColor">Sets the color of increasing values</param>
+        /// <param name="Increasing">Sets the style options of increasing values (use this for more finegrained control than the other increasing-associated arguments).</param>
+        /// <param name="DecreasingColor">Sets the color of decreasing values</param>
+        /// <param name="Decreasing">Sets the style options of decreasing values (use this for more finegrained control than the other increasing-associated arguments).</param>
+        /// <param name="WhiskerWidth">Sets the width of the whiskers relative to the box' width. For example, with 1, the whiskers are as wide as the box(es).</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Candlestick<OHLCType, XType, TextType>(
+            IEnumerable<OHLCType> open,
+            IEnumerable<OHLCType> high,
+            IEnumerable<OHLCType> low,
+            IEnumerable<OHLCType> close,
+            IEnumerable<XType> x,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<Line> Line = default,
+            Optional<Color> IncreasingColor = default,
+            Optional<FinanceMarker> Increasing = default,
+            Optional<Color> DecreasingColor = default,
+            Optional<FinanceMarker> Decreasing = default,
+            Optional<double> WhiskerWidth = default, 
+            Optional<bool> UseDefaults = default
+        )
+            where OHLCType : IConvertible
+            where XType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.Chart2D.Chart.Candlestick<OHLCType, OHLCType, OHLCType, OHLCType, XType, TextType>(
+                    open: open,
+                    high: high,
+                    low: low,
+                    close: close,
+                    x: x,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    Line: Line.ToOption(),
+                    IncreasingColor: IncreasingColor.ToOption(),
+                    Increasing: Increasing.ToOption(),
+                    DecreasingColor: DecreasingColor.ToOption(),
+                    Decreasing: Decreasing.ToOption(),
+                    WhiskerWidth: WhiskerWidth.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
     };
 
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/Chart2D.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/Chart2D.cs
@@ -1189,6 +1189,99 @@ namespace Plotly.NET.CSharp
                     Orientation: Orientation.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+
+        /// <summary>
+        /// Creates a Funnel chart.
+        ///
+        /// Funnel charts visualize stages in a process using length-encoded bars. This trace can be used to show data in either a part-to-whole representation wherein each item appears in a single stage, or in a "drop-off" representation wherein each item appears in each stage it traversed. See also the "funnelarea" trace type for a different approach to visualizing funnel data.
+        /// </summary>
+        /// <param name="x">Sets the x coordinates of the plotted data.</param>
+        /// <param name="y">Sets the y coordinates of the plotted data.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the Opacity of the trace.</param>
+        /// <param name="Width">Sets the bar width (in position axis units).</param>
+        /// <param name="Offset">Shifts the position where the bar is drawn (in position axis units). In "group" barmode, traces that set "offset" will be excluded and drawn in "overlay" mode instead.</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="Orientation">Only relevant when `stackgroup` is used, and only the first `orientation` found in the `stackgroup` will be used - including if `visible` is "legendonly" but not if it is `false`. Sets the stacking direction. With "v" ("h"), the y (x) values of subsequent traces are added. Also affects the default value of `fill`.</param>
+        /// <param name="AlignmentGroup">Set several traces linked to the same position axis or matching axes to the same alignmentgroup. This controls whether bars compute their positional range dependently or independently.</param>
+        /// <param name="OffsetGroup">Set several traces linked to the same position axis or matching axes to the same offsetgroup where bars of the same position coordinate will line up.</param>
+        /// <param name="MarkerColor">Sets the color of the bars.</param>
+        /// <param name="MarkerOutline">Sets the color of the bar outline.</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="TextInfo">Determines which trace information appear on the graph. In the case of having multiple funnels, percentages and totals are computed separately (per trace).</param>
+        /// <param name="ConnectorLineColor">Sets the line color of the funnel connector</param>
+        /// <param name="ConnectorLineStyle">Sets the line style of the funnel connector</param>
+        /// <param name="ConnectorFillColor">Sets the fill color of the funnel connector</param>
+        /// <param name="ConnectorLine">Sets the line of the funnel connector (use this for more finegrained control than the other connector line associated arguments).</param>
+        /// <param name="Connector">Sets the funnel connector (use this for more finegrained control than the other connector-associated arguments).</param>
+        /// <param name="InsideTextFont">Sets the font used for `text` lying inside the bar.</param>
+        /// <param name="OutsideTextFont">Sets the font used for `text` lying outside the bar.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Funnel<XType, YType, TextType>(
+            IEnumerable<XType> x, 
+            IEnumerable<YType> y, 
+            Optional<string> Name = default, 
+            Optional<bool> ShowLegend = default, 
+            Optional<double> Opacity = default, 
+            Optional<double> Width = default, 
+            Optional<double> Offset = default, 
+            Optional<TextType> Text = default, 
+            Optional<IEnumerable<TextType>> MultiText = default, 
+            Optional<StyleParam.TextPosition> TextPosition = default, 
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default, 
+            Optional<StyleParam.Orientation> Orientation = default, 
+            Optional<string> AlignmentGroup = default, 
+            Optional<string> OffsetGroup = default, 
+            Optional<Color> MarkerColor = default, 
+            Optional<Line> MarkerOutline = default, 
+            Optional<Marker> Marker = default, 
+            Optional<StyleParam.TextInfo> TextInfo = default, 
+            Optional<Color> ConnectorLineColor = default, 
+            Optional<StyleParam.DrawingStyle> ConnectorLineStyle = default, 
+            Optional<Color> ConnectorFillColor = default, 
+            Optional<Line> ConnectorLine = default, 
+            Optional<FunnelConnector> Connector = default, 
+            Optional<Font> InsideTextFont = default, 
+            Optional<Font> OutsideTextFont = default, 
+            Optional<bool> UseDefaults = default
+        )
+            where XType : IConvertible
+            where YType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.Chart2D.Chart.Funnel<XType, YType, TextType>(
+                    x: x,
+                    y: y,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    Width: Width.ToOption(),
+                    Offset: Offset.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    Orientation: Orientation.ToOption(),
+                    AlignmentGroup: AlignmentGroup.ToOption(),
+                    OffsetGroup: OffsetGroup.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    Marker: Marker.ToOption(),
+                    TextInfo: TextInfo.ToOption(),
+                    ConnectorLineColor: ConnectorLineColor.ToOption(),
+                    ConnectorLineStyle: ConnectorLineStyle.ToOption(),
+                    ConnectorFillColor: ConnectorFillColor.ToOption(),
+                    ConnectorLine: ConnectorLine.ToOption(),
+                    Connector: Connector.ToOption(),
+                    InsideTextFont: InsideTextFont.ToOption(),
+                    OutsideTextFont: OutsideTextFont.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
     };
 
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/Chart2D.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/Chart2D.cs
@@ -1101,6 +1101,94 @@ namespace Plotly.NET.CSharp
                     WhiskerWidth: WhiskerWidth.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+        /// <summary>
+        /// Creates a waterfall chart.
+        ///
+        /// Waterfall charts are special bar charts that help visualizing the cumulative effect of sequentially introduced positive or negative values
+        /// </summary>
+        /// <param name="x">Sets the x coordinates of the plotted data.</param>
+        /// <param name="y">Sets the y coordinates of the plotted data.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="IncreasingColor">Sets the color of increasing values</param>
+        /// <param name="Increasing">Sets the style options of increasing values (use this for more finegrained control than the other increasing-associated arguments).</param>
+        /// <param name="DecreasingColor">Sets the color of decreasing values</param>
+        /// <param name="Decreasing">Sets the style options of decreasing values (use this for more finegrained control than the other increasing-associated arguments).</param>
+        /// <param name="TotalsColor">Sets the color of total values</param>
+        /// <param name="Totals">Sets the style options of total values (use this for more finegrained control than the other increasing-associated arguments).</param>
+        /// <param name="Base">Sets where the bar base is drawn (in position axis units).</param>
+        /// <param name="Width">Sets the bar width (in position axis units).</param>
+        /// <param name="MultiWidth">Sets the individual bar width of each datum (in position axis units).</param>
+        /// <param name="Opacity">Sets the opacity of the trace.</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="TextFont">Sets the font used for `text`.</param>
+        /// <param name="Connector">Sets the waterfall connector of this trace</param>
+        /// <param name="Measure">An array containing types of measures. By default the values are considered as 'relative'. However; it is possible to use 'total' to compute the sums. Also 'absolute' could be applied to reset the computed total or to declare an initial value where needed.</param>
+        /// <param name="AlignmentGroup">Set several traces linked to the same position axis or matching axes to the same alignmentgroup. This controls whether bars compute their positional range dependently or independently.</param>
+        /// <param name="OffsetGroup">Set several traces linked to the same position axis or matching axes to the same offsetgroup where bars of the same position coordinate will line up.</param>
+        /// <param name="Orientation">Only relevant when `stackgroup` is used, and only the first `orientation` found in the `stackgroup` will be used - including if `visible` is "legendonly" but not if it is `false`. Sets the stacking direction. With "v" ("h"), the y (x) values of subsequent traces are added. Also affects the default value of `fill`.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Waterfall<XType, YType, TextType>(
+            IEnumerable<XType> x,
+            IEnumerable<YType> y,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<Color> IncreasingColor = default,
+            Optional<FinanceMarker> Increasing = default,
+            Optional<Color> DecreasingColor = default,
+            Optional<FinanceMarker> Decreasing = default,
+            Optional<Color> TotalsColor = default,
+            Optional<FinanceMarker> Totals = default,
+            Optional<double> Base = default,
+            Optional<double> Width = default,
+            Optional<IEnumerable<double>> MultiWidth = default,
+            Optional<double> Opacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Font> TextFont = default,
+            Optional<WaterfallConnector> Connector = default,
+            Optional<IEnumerable<StyleParam.WaterfallMeasure>> Measure = default,
+            Optional<string> AlignmentGroup = default,
+            Optional<string> OffsetGroup = default,
+            Optional<StyleParam.Orientation> Orientation = default,
+            Optional<bool> UseDefaults = default
+        )
+            where XType : IConvertible
+            where YType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.Chart2D.Chart.Waterfall<XType, YType, TextType>(
+                    x: x,
+                    y: y,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    IncreasingColor: IncreasingColor.ToOption(),
+                    Increasing: Increasing.ToOption(),
+                    DecreasingColor: DecreasingColor.ToOption(),
+                    Decreasing: Decreasing.ToOption(),
+                    TotalsColor: TotalsColor.ToOption(),
+                    Totals: Totals.ToOption(),
+                    Base: Base.ToOption(),
+                    Width: Width.ToOption(),
+                    MultiWidth: MultiWidth.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    TextFont: TextFont.ToOption(),
+                    Connector: Connector.ToOption(),
+                    Measure: Measure.ToOption(),
+                    AlignmentGroup: AlignmentGroup.ToOption(),
+                    OffsetGroup: OffsetGroup.ToOption(),
+                    Orientation: Orientation.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
     };
 
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/Chart2D.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/Chart2D.cs
@@ -971,5 +971,72 @@ namespace Plotly.NET.CSharp
                     ShowScale: ShowScale.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+
+        /// <summary>
+        /// Creates an OHLC chart.
+        ///
+        /// The ohlc (short for Open-High-Low-Close) is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The tip of the lines represent the `low` and `high` values and the horizontal segments represent the `open` and `close` values. Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing items are drawn in green whereas decreasing are drawn in red.
+        /// </summary>
+        /// <param name="open">Sets the open values.</param>
+        /// <param name="high">Sets the high values.</param>
+        /// <param name="low">Sets the low values.</param>
+        /// <param name="close">Sets the close values.</param>
+        /// <param name="x">Sets the x coordinates. If absent, linear coordinate will be generated.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover.</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the Opacity otf the trace.</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="Line">Sets the line of this trace.</param>
+        /// <param name="IncreasingColor">Sets the color of increasing values</param>
+        /// <param name="Increasing">Sets the style options of increasing values (use this for more finegrained control than the other increasing-associated arguments).</param>
+        /// <param name="DecreasingColor">Sets the color of decreasing values</param>
+        /// <param name="Decreasing">Sets the style options of decreasing values (use this for more finegrained control than the other increasing-associated arguments).</param>
+        /// <param name="TickWidth">Sets the width of the open/close tick marks relative to the "x" minimal interval.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart OHLC<OHLCType, XType, TextType>(
+            IEnumerable<OHLCType> open, 
+            IEnumerable<OHLCType> high, 
+            IEnumerable<OHLCType> low, 
+            IEnumerable<OHLCType> close, 
+            IEnumerable<XType> x, 
+            Optional<string> Name = default, 
+            Optional<bool> ShowLegend = default, 
+            Optional<double> Opacity = default, 
+            Optional<TextType> Text = default, 
+            Optional<IEnumerable<TextType>> MultiText = default, 
+            Optional<Line> Line = default, 
+            Optional<Color> IncreasingColor = default, 
+            Optional<FinanceMarker> Increasing = default, 
+            Optional<Color> DecreasingColor = default, 
+            Optional<FinanceMarker> Decreasing = default, 
+            Optional<double> TickWidth = default, 
+            Optional<bool> UseDefaults = default
+        )
+            where OHLCType : IConvertible
+            where XType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.Chart2D.Chart.OHLC<OHLCType, OHLCType, OHLCType, OHLCType, XType, TextType>(
+                    open: open,
+                    high: high,
+                    low: low,
+                    close: close,
+                    x: x,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    Line: Line.ToOption(),
+                    IncreasingColor: IncreasingColor.ToOption(),
+                    Increasing : Increasing.ToOption(),
+                    DecreasingColor: DecreasingColor.ToOption(),
+                    Decreasing: Decreasing.ToOption(),
+                    TickWidth: TickWidth.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
     };
+
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -94,6 +94,80 @@ namespace Plotly.NET.CSharp
                     Sort: Sort.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+        /// <summary>
+        /// Creates a FunnelArea chart.
+        ///
+        /// FunnelArea charts visualize stages in a process using area-encoded trapezoids, which can be used to show data in a part-to-whole representation similar to a piechart,
+        /// wherein each item appears in a single stage. See also the "funnel" chart for a different approach to visualizing funnel data.
+        /// </summary>
+        /// <param name="values">Sets the values of the sectors</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Labels">Sets the sector labels. If `labels` entries are duplicated, the associated `values` are summed.</param>
+        /// <param name="Text">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="MultiText">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="TextPosition">Sets the positions of the `text` elements with respects to the (x,y) coordinates.</param>
+        /// <param name="MultiTextPosition">Sets the positions of the `text` elements with respects to the (x,y) coordinates.</param>
+        /// <param name="SectionColors">Sets the colors associated with each section.</param>
+        /// <param name="SectionOutlineColor">Sets the color of the section outline.</param>
+        /// <param name="SectionOutlineWidth">Sets the width of the section outline.</param>
+        /// <param name="SectionOutlineMultiWidth">Sets the width of each individual section outline.</param>
+        /// <param name="SectionOutline">Sets the section outline (use this for more finegrained control than the other section outline-associated arguments).</param>
+        /// <param name="Marker">Sets the marker of this trace.</param>
+        /// <param name="TextInfo">Determines which trace information appear on the graph.</param>
+        /// <param name="AspectRatio"></param>
+        /// <param name="BaseRatio"></param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart FunnelArea<ValuesType, LabelsType, TextType>(
+            IEnumerable<ValuesType> values, 
+            Optional<string> Name = default, 
+            Optional<bool> ShowLegend = default, 
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default, 
+            Optional<IEnumerable<LabelsType>> Labels = default, 
+            Optional<TextType> Text = default, 
+            Optional<IEnumerable<TextType>> MultiText = default, 
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<IEnumerable<Color>> SectionColors = default, 
+            Optional<Color> SectionOutlineColor = default, 
+            Optional<double> SectionOutlineWidth = default, 
+            Optional<IEnumerable<double>> SectionOutlineMultiWidth = default, 
+            Optional<Line> SectionOutline = default, 
+            Optional<Marker> Marker = default, 
+            Optional<StyleParam.TextInfo> TextInfo = default, 
+            Optional<double> AspectRatio = default, 
+            Optional<double> BaseRatio = default, 
+            Optional<bool> UseDefaults = default
+        )
+            where ValuesType : IConvertible
+            where LabelsType : IConvertible
+            where TextType   : IConvertible
+            =>
+                Plotly.NET.ChartDomain.Chart.FunnelArea<ValuesType, LabelsType, TextType>(
+                    values: values,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Labels: Labels.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    SectionColors: SectionColors.ToOption(),
+                    SectionOutlineColor: SectionOutlineColor.ToOption(),
+                    SectionOutlineWidth: SectionOutlineWidth.ToOption(),
+                    SectionOutlineMultiWidth: SectionOutlineMultiWidth.ToOption(),
+                    SectionOutline: SectionOutline.ToOption(),
+                    Marker: Marker.ToOption(),
+                    TextInfo: TextInfo.ToOption(),
+                    AspectRatio: AspectRatio.ToOption(),
+                    BaseRatio: BaseRatio.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
 
     }
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -169,5 +169,64 @@ namespace Plotly.NET.CSharp
                     UseDefaults: UseDefaults.ToOption()
                 );
 
+        /// <summary>
+        /// Creates an Indicator chart.
+        ///
+        /// An indicator is used to visualize a single `value` along with some contextual information such as `steps` or a `threshold`, using a combination of three visual elements: a number, a delta, and/or a gauge.
+        /// Deltas are taken with respect to a `reference`.
+        /// Gauges can be either angular or bullet (aka linear) gauges.
+        /// </summary>
+        /// <param name="value">Sets the number to be displayed.</param>
+        /// <param name="mode">Determines how the value is displayed on the graph. `number` displays the value numerically in text. `delta` displays the difference to a reference value in text. Finally, `gauge` displays the value graphically on an axis.</param>
+        /// <param name="Range">Sets the Range of the Gauge axis</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover.</param>
+        /// <param name="Title">Sets the title of this trace.</param>
+        /// <param name="Domain">Sets the domain of this trace.</param>
+        /// <param name="Align">Sets the horizontal alignment of the `text` within the box. Note that this attribute has no effect if an angular gauge is displayed: in this case, it is always centered</param>
+        /// <param name="DeltaReference"></param>
+        /// <param name="Delta">Sets how the delta to the delta reference is displayed</param>
+        /// <param name="Number">Sets the styles of the displayed number</param>
+        /// <param name="GaugeShape">Sets the shape of the gauge</param>
+        /// <param name="Gauge">Sets the styles of the gauge</param>
+        /// <param name="ShowGaugeAxis">Wether or not to show the gauge axis</param>
+        /// <param name="GaugeAxis">Sets the gauge axis</param>
+        /// <param name="UseDefaults"></param>
+        public static GenericChart.GenericChart Indicator<ValueType>(
+            ValueType value,
+            StyleParam.IndicatorMode mode,
+            Optional<StyleParam.Range> Range = default,
+            Optional<string> Name = default,
+            Optional<string> Title = default,
+            Optional<Domain> Domain = default,
+            Optional<StyleParam.IndicatorAlignment> Align = default,
+            Optional<ValueType> DeltaReference = default,
+            Optional<IndicatorDelta> Delta = default,
+            Optional<IndicatorNumber> Number = default,
+            Optional<StyleParam.IndicatorGaugeShape> GaugeShape = default,
+            Optional<IndicatorGauge> Gauge = default,
+            Optional<bool> ShowGaugeAxis = default,
+            Optional<LinearAxis> GaugeAxis = default,
+            Optional<bool> UseDefaults = default
+        )
+            where ValueType : IConvertible
+            =>
+                Plotly.NET.ChartDomain.Chart.Indicator<ValueType>(
+                    value: value,
+                    mode: mode,
+                    Range: Range.ToOption(),
+                    Name: Name.ToOption(),
+                    Title: Title.ToOption(),
+                    Domain: Domain.ToOption(),
+                    Align: Align.ToOption(),
+                    DeltaReference: DeltaReference.ToOption(),
+                    Delta: Delta.ToOption(),
+                    Number: Number.ToOption(),
+                    GaugeShape: GaugeShape.ToOption(),
+                    Gauge: Gauge.ToOption(),
+                    ShowGaugeAxis: ShowGaugeAxis.ToOption(),
+                    GaugeAxis: GaugeAxis.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
     }
 }

--- a/src/Plotly.NET.CSharp/GenericChartExtensions.cs
+++ b/src/Plotly.NET.CSharp/GenericChartExtensions.cs
@@ -347,6 +347,23 @@ namespace Plotly.NET.CSharp
                     Layers: Layers.ToOption(),
                     Id: Id.ToOption()
                 ).Invoke(gChart);
-            }
 
+        /// <summary>
+        /// Sets the range slider for the xAxis
+        /// </summary>
+        /// <param name="gChart">The chart for which to set the x axis range slider</param>
+        /// <param name="rangeSlider">The rangeslider to set</param>
+        /// <param name="Id">The id of the respective x axis</param>
+        /// <returns></returns>
+        public static GenericChart.GenericChart WithXAxisRangeSlider(
+            this GenericChart.GenericChart gChart,
+            RangeSlider rangeSlider,
+            Optional<StyleParam.SubPlotId> Id = default
+        )
+            =>
+                Plotly.NET.Chart.WithXAxisRangeSlider(
+                    rangeSlider: rangeSlider,
+                    Id: Id.ToOption()
+                ).Invoke(gChart);
+    }
 }

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -105,7 +105,10 @@ namespace TestConsoleApp
                             x: new double [] { 1200, 909.4, 600.6, 300, 80 },
                             y: new string[] { "A", "B", "C", "D", "E"}
                         ),
-                        Chart.Invisible(),
+                        Chart.FunnelArea<int, string, string>(
+                            values: new int [] { 5, 4, 3, 2, 1 },
+                            MultiText: new string[] { "A", "B", "C", "D", "E"}
+                        ),
                         Chart.Invisible(),
 
                         //3D traces

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -109,7 +109,11 @@ namespace TestConsoleApp
                             values: new int [] { 5, 4, 3, 2, 1 },
                             MultiText: new string[] { "A", "B", "C", "D", "E"}
                         ),
-                        Chart.Invisible(),
+                        Chart.Indicator<double>(
+                            value: 200,
+                            mode: Plotly.NET.StyleParam.IndicatorMode.NumberDeltaGauge,
+                            DeltaReference: 160
+                        ),
 
                         //3D traces
                         Chart.Scatter3D<int,int,int,string>(

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -10,7 +10,7 @@ namespace TestConsoleApp
         static void Main(string[] args)
         {
             Chart.Grid(
-                nRows: 9,
+                nRows: 10,
                 nCols: 6,
                 gCharts:
                     new GenericChart[]
@@ -67,6 +67,23 @@ namespace TestConsoleApp
                            y: new int [] { 1,2,2,2,3,4,5,5 },
                            ShowScale: false
                         ),
+
+                        //2D Finance traces
+                        Chart.OHLC<double,DateTime,string>(
+                            open: new double [] {1.2, 2.7},
+                            high: new double [] {1.8, 8.5},
+                            low: new double []  {0.5, 0.1},
+                            close: new double [] {1.1, 2.9},
+                            x: new DateTime [] {DateTime.Parse("07/07/2021"), DateTime.Parse("07/07/2022") }
+                        ).WithXAxisRangeSlider(
+                            rangeSlider: Plotly.NET.LayoutObjects.RangeSlider.init(
+                                Visible: false
+                        )),
+                        Chart.Invisible(),
+                        Chart.Invisible(),
+                        Chart.Invisible(),
+                        Chart.Invisible(),
+                        Chart.Invisible(),
 
                         //3D traces
                         Chart.Scatter3D<int,int,int,string>(
@@ -175,17 +192,11 @@ namespace TestConsoleApp
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),
-                        Chart.Invisible(),
+                        Chart.Invisible()
                     }
             )
-                .WithSize(1000, 1800)
-                .Show();
-            Chart.Column<int, string, string>(
-                values: new int[] { 3, 4 },
-                Keys: new string[] { "first", "second" },
-                Width: 1,
-                Base: 4
-            ).Show();
+            .WithSize(1000, 1800)
+            .Show();
         }
     }
 }

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -101,7 +101,10 @@ namespace TestConsoleApp
                                 Plotly.NET.StyleParam.WaterfallMeasure.Total
                             }
                         ),
-                        Chart.Invisible(),
+                        Chart.Funnel<double, string, string>(
+                            x: new double [] { 1200, 909.4, 600.6, 300, 80 },
+                            y: new string[] { "A", "B", "C", "D", "E"}
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
 
@@ -215,7 +218,7 @@ namespace TestConsoleApp
                         Chart.Invisible()
                     }
             )
-            .WithSize(1000, 1800)
+            .WithSize(1200, 2000)
             .Show();
         }
     }

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -78,7 +78,7 @@ namespace TestConsoleApp
                         ).WithXAxisRangeSlider(
                             rangeSlider: Plotly.NET.LayoutObjects.RangeSlider.init(
                                 Visible: false
-                        )),                        
+                        )),
                         Chart.Candlestick<double,DateTime,string>(
                             open: new double [] {1.2, 2.7},
                             high: new double [] {1.8, 8.5},
@@ -89,7 +89,18 @@ namespace TestConsoleApp
                             rangeSlider: Plotly.NET.LayoutObjects.RangeSlider.init(
                                 Visible: false
                         )),
-                        Chart.Invisible(),
+                        Chart.Waterfall<string, int, string>(
+                            x: new string [] {"A", "B", "Net", "Purch", "Other", "Profit"},
+                            y: new int [] {60, 80, 0, -40, -20, 0},
+                            Measure: new Plotly.NET.StyleParam.WaterfallMeasure [] {
+                                Plotly.NET.StyleParam.WaterfallMeasure.Relative,
+                                Plotly.NET.StyleParam.WaterfallMeasure.Relative,
+                                Plotly.NET.StyleParam.WaterfallMeasure.Total,
+                                Plotly.NET.StyleParam.WaterfallMeasure.Relative,
+                                Plotly.NET.StyleParam.WaterfallMeasure.Relative,
+                                Plotly.NET.StyleParam.WaterfallMeasure.Total
+                            }
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -78,8 +78,17 @@ namespace TestConsoleApp
                         ).WithXAxisRangeSlider(
                             rangeSlider: Plotly.NET.LayoutObjects.RangeSlider.init(
                                 Visible: false
+                        )),                        
+                        Chart.Candlestick<double,DateTime,string>(
+                            open: new double [] {1.2, 2.7},
+                            high: new double [] {1.8, 8.5},
+                            low: new double []  {0.5, 0.1},
+                            close: new double [] {1.1, 2.9},
+                            x: new DateTime [] {DateTime.Parse("07/07/2021"), DateTime.Parse("07/07/2022") }
+                        ).WithXAxisRangeSlider(
+                            rangeSlider: Plotly.NET.LayoutObjects.RangeSlider.init(
+                                Visible: false
                         )),
-                        Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),


### PR DESCRIPTION
This PR will adds C# bindings for the following high level chart APIs:

- [x] OHLC
- [x] Candlestick
- [x] Waterfall
- [x] Funnel
- [x] Funnel Area
- [x] Indicator

Additionally, some GenericChart extensions have been added:

- [x] WithXAxisrangeSlider