### PR TITLE
[C#] Add C# bindings for missing Map charts

### DIFF
--- a/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
@@ -328,6 +328,83 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a BubbleGeo chart.
+        ///
+        /// In general, BubbleGeo Plots plot two-dimensional data as points using plotly's base geo map, additionally using the point size as a third dimension.
+        /// </summary>
+        /// <param name="longitudes">Sets the longitude coordinates (in degrees East).</param>
+        /// <param name="latitudes">Sets the latitude coordinates (in degrees North).</param>
+        /// <param name="sizes">Sets the size of the points.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LocationMode">Determines the set of locations used to match entries in `locations` to regions on the map. Values "ISO-3", "USA-states", "country names" correspond to features on the base map and value "geojson-id" corresponds to features from a custom GeoJSON linked to the `geojson` attribute.</param>
+        /// <param name="GeoJson">Sets optional GeoJSON data associated with this trace. If not given, the features on the base map are used. It can be set as a valid GeoJSON object or as a URL string. Note that we only accept GeoJSONs of type "FeatureCollection" or "Feature" with geometries of type "Polygon" or "MultiPolygon".</param>
+        /// <param name="FeatureIdKey">Sets the key in GeoJSON features which is used as id to match the items included in the `locations` array. Only has an effect when `geojson` is set. Support nested property, for example "properties.name".</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart BubbleGeo<LongitudesType, LatitudesType, TextType>(
+            IEnumerable<LongitudesType> longitudes,
+            IEnumerable<LatitudesType> latitudes,
+            IEnumerable<int> sizes,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<StyleParam.LocationFormat> LocationMode = default,
+            Optional<object> GeoJson = default,
+            Optional<string> FeatureIdKey = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LongitudesType : IConvertible
+            where LatitudesType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.BubbleGeo<LongitudesType, LatitudesType, TextType>(
+                    longitudes: longitudes,
+                    latitudes: latitudes,
+                    sizes: sizes,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LocationMode: LocationMode.ToOption(),
+                    GeoJson: GeoJson.ToOption(),
+                    FeatureIdKey: FeatureIdKey.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates a DensityMapbox Chart that draws a bivariate kernel density estimation with a Gaussian kernel from `lon` and `lat` coordinates and optional `z` values using a colorscale.
         ///
         /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
@@ -495,6 +495,164 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a PointMapbox chart, where data is visualized on a geographic map as points using mapbox.
+        ///
+        /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.
+        ///
+        /// You might need a Mapbox token, which you can also configure with Chart.withMapbox.
+        /// </summary>
+        /// <param name="longitudes">Sets the longitude coordinates (in degrees East).</param>
+        /// <param name="latitudes">Sets the latitude coordinates (in degrees North).</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="Below">Determines if this scattermapbox trace's layers are to be inserted before the layer with the specified ID. By default, scattermapbox layers are inserted above all the base layers. To place the scattermapbox layers above every other layer, set `below` to "''".</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart PointMapbox<LongitudesType, LatitudesType, TextType>(
+            IEnumerable<LongitudesType> longitudes,
+            IEnumerable<LatitudesType> latitudes,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<string> Below = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LongitudesType : IConvertible
+            where LatitudesType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.PointMapbox<LongitudesType, LatitudesType, TextType>(
+                    longitudes: longitudes,
+                    latitudes: latitudes,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    Below: Below.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
+        /// Creates a LineMapbox chart, where data is visualized on a geographic map connected by a line using mapbox.
+        ///
+        /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.
+        ///
+        /// You might need a Mapbox token, which you can also configure with Chart.withMapbox.
+        /// </summary>
+        /// <param name="longitudes">Sets the longitude coordinates (in degrees East).</param>
+        /// <param name="latitudes">Sets the latitude coordinates (in degrees North).</param>
+        /// <param name="ShowMarkers"></param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="Below">Determines if this scattermapbox trace's layers are to be inserted before the layer with the specified ID. By default, scattermapbox layers are inserted above all the base layers. To place the scattermapbox layers above every other layer, set `below` to "''".</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart LineMapbox<LongitudesType, LatitudesType, TextType>(
+            IEnumerable<LongitudesType> longitudes,
+            IEnumerable<LatitudesType> latitudes,
+            Optional<bool> ShowMarkers = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<string> Below = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LongitudesType : IConvertible
+            where LatitudesType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.LineMapbox<LongitudesType, LatitudesType, TextType>(
+                    longitudes: longitudes,
+                    latitudes: latitudes,
+                    ShowMarkers: ShowMarkers.ToOption(),
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    LineWidth: LineWidth.ToOption(),
+                    LineDash: LineDash.ToOption(),
+                    Line: Line.ToOption(),
+                    Below: Below.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates a DensityMapbox Chart that draws a bivariate kernel density estimation with a Gaussian kernel from `lon` and `lat` coordinates and optional `z` values using a colorscale.
         ///
         /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
@@ -13,6 +13,61 @@ namespace Plotly.NET.CSharp
     public static partial class Chart
     {
         /// <summary>
+        /// Creates a choropleth map using plotly's base geo map.
+        ///
+        /// A choropleth map is a type of thematic map in which a set of pre-defined areas is colored or patterned in proportion to a statistical variable that represents an aggregate summary of a geographic characteristic within each area, such as population density or per-capita income.
+        /// </summary>
+        /// <param name="locations">Sets the locations which will be colored. See LocationMode for more info.</param>
+        /// <param name="z">The color values for each location</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover.</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="GeoJson">Sets optional GeoJSON data associated with this trace. If not given, the features on the base map are used. It can be set as a valid GeoJSON object or as a URL string. Note that we only accept GeoJSONs of type "FeatureCollection" or "Feature" with geometries of type "Polygon" or "MultiPolygon".</param>
+        /// <param name="FeatureIdKey">Sets the key in GeoJSON features which is used as id to match the items included in the `locations` array. Only has an effect when `geojson` is set. Support nested property, for example "properties.name".</param>
+        /// <param name="Text">Sets the text elements associated with each location.</param>
+        /// <param name="MultiText">Sets the text elements associated with each location.</param>
+        /// <param name="ColorBar">Sets the colorbar.</param>
+        /// <param name="ColorScale">Sets the colorscale.</param>
+        /// <param name="ShowScale">Determines whether or not a colorbar is displayed for this trace.</param>
+        /// <param name="ReverseScale">Reverses the color mapping if true.</param>
+        /// <param name="LocationMode">Determines the set of locations used to match entries in `locations` to regions on the map. Values "ISO-3", "USA-states", "country names" correspond to features on the base map and value "geojson-id" corresponds to features from a custom GeoJSON linked to the `geojson` attribute.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart ChoroplethMap<ZType, TextType>(
+            IEnumerable<string> locations, 
+            IEnumerable<ZType> z, 
+            Optional<string> Name = default, 
+            Optional<bool> ShowLegend = default, 
+            Optional<object> GeoJson = default, 
+            Optional<string> FeatureIdKey = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default, 
+            Optional<ColorBar> ColorBar = default, 
+            Optional<StyleParam.Colorscale> ColorScale = default,
+            Optional<bool> ShowScale = default, 
+            Optional<bool> ReverseScale = default,
+            Optional<StyleParam.LocationFormat> LocationMode = default,
+            Optional<bool> UseDefaults = default
+        )
+            where ZType: IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.ChoroplethMap<ZType, TextType>(
+                    locations: locations,
+                    z: z,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    GeoJson: GeoJson.ToOption(),
+                    FeatureIdKey: FeatureIdKey.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    ColorBar: ColorBar.ToOption(),
+                    ColorScale: ColorScale.ToOption(),
+                    ShowScale: ShowScale.ToOption(),
+                    ReverseScale: ReverseScale.ToOption(),
+                    LocationMode: LocationMode.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates a ScatterGeo chart, where data is visualized using plotly's base geo map.
         ///
         /// In general, ScatterGeo Plots plot two-dimensional data on a geo map via (lat,lon) coordinates.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
@@ -162,6 +162,80 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a PointGeo chart.
+        ///
+        /// In general, PointGeo Plots plot two-dimensional data as points using plotly's base geo map.
+        /// </summary>
+        /// <param name="longitudes">Sets the longitude coordinates (in degrees East).</param>
+        /// <param name="latitudes">Sets the latitude coordinates (in degrees North).</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LocationMode">Determines the set of locations used to match entries in `locations` to regions on the map. Values "ISO-3", "USA-states", "country names" correspond to features on the base map and value "geojson-id" corresponds to features from a custom GeoJSON linked to the `geojson` attribute.</param>
+        /// <param name="GeoJson">Sets optional GeoJSON data associated with this trace. If not given, the features on the base map are used. It can be set as a valid GeoJSON object or as a URL string. Note that we only accept GeoJSONs of type "FeatureCollection" or "Feature" with geometries of type "Polygon" or "MultiPolygon".</param>
+        /// <param name="FeatureIdKey">Sets the key in GeoJSON features which is used as id to match the items included in the `locations` array. Only has an effect when `geojson` is set. Support nested property, for example "properties.name".</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart PointGeo<LongitudesType, LatitudesType, TextType>(
+            IEnumerable<LongitudesType> longitudes,
+            IEnumerable<LatitudesType> latitudes,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<StyleParam.LocationFormat> LocationMode = default,
+            Optional<Object> GeoJson = default,
+            Optional<string> FeatureIdKey = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LongitudesType : IConvertible
+            where LatitudesType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.PointGeo<LongitudesType, LatitudesType, TextType>(
+                    longitudes: longitudes,
+                    latitudes: latitudes,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LocationMode: LocationMode.ToOption(),
+                    GeoJson: GeoJson.ToOption(),
+                    FeatureIdKey: FeatureIdKey.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates a DensityMapbox Chart that draws a bivariate kernel density estimation with a Gaussian kernel from `lon` and `lat` coordinates and optional `z` values using a colorscale.
         ///
         /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
@@ -124,7 +124,7 @@ namespace Plotly.NET.CSharp
             Optional<StyleParam.DrawingStyle> LineDash = default,
             Optional<Line> Line = default,
             Optional<StyleParam.LocationFormat> LocationMode = default,
-            Optional<Object> GeoJson = default,
+            Optional<object> GeoJson = default,
             Optional<string> FeatureIdKey = default,
             Optional<bool> UseDefaults = default
         )
@@ -204,7 +204,7 @@ namespace Plotly.NET.CSharp
             Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
             Optional<Marker> Marker = default,
             Optional<StyleParam.LocationFormat> LocationMode = default,
-            Optional<Object> GeoJson = default,
+            Optional<object> GeoJson = default,
             Optional<string> FeatureIdKey = default,
             Optional<bool> UseDefaults = default
         )
@@ -229,6 +229,98 @@ namespace Plotly.NET.CSharp
                     MarkerSymbol: MarkerSymbol.ToOption(),
                     MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
                     Marker: Marker.ToOption(),
+                    LocationMode: LocationMode.ToOption(),
+                    GeoJson: GeoJson.ToOption(),
+                    FeatureIdKey: FeatureIdKey.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
+        /// Creates a LineGeo chart.
+        ///
+        /// In general, LineGeo Plots plot two-dimensional data connected by lines using plotly's base geo map.
+        /// </summary>
+        /// <param name="longitudes">Sets the longitude coordinates (in degrees East).</param>
+        /// <param name="latitudes">Sets the latitude coordinates (in degrees North).</param>
+        /// <param name="ShowMarkers"></param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="LocationMode">Determines the set of locations used to match entries in `locations` to regions on the map. Values "ISO-3", "USA-states", "country names" correspond to features on the base map and value "geojson-id" corresponds to features from a custom GeoJSON linked to the `geojson` attribute.</param>
+        /// <param name="GeoJson">Sets optional GeoJSON data associated with this trace. If not given, the features on the base map are used. It can be set as a valid GeoJSON object or as a URL string. Note that we only accept GeoJSONs of type "FeatureCollection" or "Feature" with geometries of type "Polygon" or "MultiPolygon".</param>
+        /// <param name="FeatureIdKey">Sets the key in GeoJSON features which is used as id to match the items included in the `locations` array. Only has an effect when `geojson` is set. Support nested property, for example "properties.name".</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart LineGeo<LongitudesType, LatitudesType, TextType>(
+            IEnumerable<LongitudesType> longitudes,
+            IEnumerable<LatitudesType> latitudes,
+            Optional<bool> ShowMarkers = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<StyleParam.LocationFormat> LocationMode = default,
+            Optional<object> GeoJson = default,
+            Optional<string> FeatureIdKey = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LongitudesType : IConvertible
+            where LatitudesType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.LineGeo<LongitudesType, LatitudesType, TextType>(
+                    longitudes: longitudes,
+                    latitudes: latitudes,
+                    ShowMarkers: ShowMarkers.ToOption(),
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    LineWidth: LineWidth.ToOption(),
+                    LineDash: LineDash.ToOption(),
+                    Line: Line.ToOption(),
                     LocationMode: LocationMode.ToOption(),
                     GeoJson: GeoJson.ToOption(),
                     FeatureIdKey: FeatureIdKey.ToOption(),

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
@@ -405,6 +405,96 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a ScatterMapbox chart, where data is visualized on a geographic map using mapbox.
+        ///
+        /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.
+        ///
+        /// You might need a Mapbox token, which you can also configure with Chart.withMapbox.
+        ///
+        /// ScatterMapbox charts are the basis of PointMapbox, LineMapbox, and BubbleMapbox Charts, and can be customized as such. We also provide abstractions for those: Chart.PointMapbox, Chart.LineMapbox, Chart.BubbleMapbox
+        /// </summary>
+        /// <param name="longitudes">Sets the longitude coordinates (in degrees East).</param>
+        /// <param name="latitudes">Sets the latitude coordinates (in degrees North).</param>
+        /// <param name="mode">Determines the drawing mode for this scatter trace.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="Below">Determines if this scattermapbox trace's layers are to be inserted before the layer with the specified ID. By default, scattermapbox layers are inserted above all the base layers. To place the scattermapbox layers above every other layer, set `below` to "''".</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart ScatterMapbox<LongitudesType, LatitudesType, TextType>(
+            IEnumerable<LongitudesType> longitudes,
+            IEnumerable<LatitudesType> latitudes,
+            StyleParam.Mode mode,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<string> Below = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LongitudesType : IConvertible
+            where LatitudesType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.ScatterMapbox<LongitudesType, LatitudesType, TextType>(
+                    longitudes: longitudes,
+                    latitudes: latitudes,
+                    mode: mode,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    LineWidth: LineWidth.ToOption(),
+                    LineDash: LineDash.ToOption(),
+                    Line: Line.ToOption(),
+                    Below: Below.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates a DensityMapbox Chart that draws a bivariate kernel density estimation with a Gaussian kernel from `lon` and `lat` coordinates and optional `z` values using a colorscale.
         ///
         /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
@@ -726,6 +726,67 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a choropleth map using mapbox.
+        ///
+        /// A choropleth map is a type of thematic map in which a set of pre-defined areas is colored or patterned in proportion to a statistical variable that represents an aggregate summary of a geographic characteristic within each area, such as population density or per-capita income.
+        ///
+        /// GeoJSON features to be filled are set in `geojson` The data that describes the choropleth value-to-color mapping is set in `locations` and `z`.
+        ///
+        /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.
+        ///
+        /// You might need a Mapbox token, which you can also configure with Chart.withMapbox.
+        /// </summary>
+        /// <param name="locations">Sets the coordinates via location IDs or names. Coordinates correspond to the centroid of each location given. See `locationmode` for more info.</param>
+        /// <param name="z">The color values for each location</param>
+        /// <param name="geoJson">Sets the GeoJSON data associated with this trace. It can be set as a valid GeoJSON object or as a URL string. Note that we only accept GeoJSONs of type "FeatureCollection" or "Feature" with geometries of type "Polygon" or "MultiPolygon".</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover.</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="FeatureIdKey">Sets the key in GeoJSON features which is used as id to match the items included in the `locations` array. Support nested property, for example "properties.name".</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="ColorBar">Sets the colorbar.</param>
+        /// <param name="ColorScale">Sets the colorscale.</param>
+        /// <param name="ShowScale">Determines whether or not a colorbar is displayed for this trace.</param>
+        /// <param name="ReverseScale">Reverses the color mapping if true.</param>
+        /// <param name="Below">Determines if this scattermapbox trace's layers are to be inserted before the layer with the specified ID. By default, scattermapbox layers are inserted above all the base layers. To place the scattermapbox layers above every other layer, set `below` to "''".</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart ChoroplethMapbox<ZType, TextType>(
+            IEnumerable<string> locations,
+            IEnumerable<ZType> z,
+            object geoJson,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<string> FeatureIdKey = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<ColorBar> ColorBar = default,
+            Optional<StyleParam.Colorscale> ColorScale = default,
+            Optional<bool> ShowScale = default,
+            Optional<bool> ReverseScale = default,
+            Optional<string> Below = default,
+            Optional<bool> UseDefaults = default
+        )
+            where ZType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.ChoroplethMapbox<ZType, TextType>(
+                    locations: locations,
+                    z: z,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    geoJson: geoJson,
+                    FeatureIdKey: FeatureIdKey.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    ColorBar: ColorBar.ToOption(),
+                    ColorScale: ColorScale.ToOption(),
+                    ShowScale: ShowScale.ToOption(),
+                    ReverseScale: ReverseScale.ToOption(),
+                    Below: Below.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates a DensityMapbox Chart that draws a bivariate kernel density estimation with a Gaussian kernel from `lon` and `lat` coordinates and optional `z` values using a colorscale.
         ///
         /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartMap.cs
@@ -653,6 +653,79 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a BubbleMapbox chart, where data is visualized on a geographic map as points using mapbox, additionally using the point size as a third dimension.
+        ///
+        /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.
+        ///
+        /// You might need a Mapbox token, which you can also configure with Chart.withMapbox.
+        /// </summary>
+        /// <param name="longitudes">Sets the longitude coordinates (in degrees East).</param>
+        /// <param name="latitudes">Sets the latitude coordinates (in degrees North).</param>
+        /// <param name="sizes">Sets the size of the points.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="Below">Determines if this scattermapbox trace's layers are to be inserted before the layer with the specified ID. By default, scattermapbox layers are inserted above all the base layers. To place the scattermapbox layers above every other layer, set `below` to "''".</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart BubbleMapbox<LongitudesType, LatitudesType, TextType>(
+            IEnumerable<LongitudesType> longitudes,
+            IEnumerable<LatitudesType> latitudes,
+            IEnumerable<int> sizes,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<string> Below = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LongitudesType : IConvertible
+            where LatitudesType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartMap.Chart.BubbleMapbox<LongitudesType, LatitudesType, TextType>(
+                    longitudes: longitudes,
+                    latitudes: latitudes,
+                    sizes: sizes,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    Below: Below.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates a DensityMapbox Chart that draws a bivariate kernel density estimation with a Gaussian kernel from `lon` and `lat` coordinates and optional `z` values using a colorscale.
         ///
         /// Customize the mapbox layers, style, etc. by using Chart.withMapbox.

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -484,12 +484,12 @@ namespace TestConsoleApp
                                     latitudes: new int [] { 11, 1 },
                                     Name: "linemapbox"
                                 ),
-                                //Chart.BubbleMapbox<int,int,string>(
-                                //    longitudes: new int [] { 80,  -80},
-                                //    latitudes: new int [] { 20, -20 },
-                                //    sizes: new int [] { 10, 20 },
-                                //    Name: "bubblemapbox"
-                                //),
+                                Chart.BubbleMapbox<int,int,string>(
+                                    longitudes: new int [] { 22, -11},
+                                    latitudes: new int [] { 5, 5 },
+                                    sizes: new int [] { 10, 20 },
+                                    Name: "bubblemapbox"
+                                ),
                             }
                         ).WithMaboxStyle(
                             Style: MapboxStyle.OpenStreetMap,

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -465,17 +465,53 @@ namespace TestConsoleApp
                             LegendGroup: "other-geo",
                             LegendGroupTitle: Plotly.NET.Title.init("other geo charts", Font: Plotly.NET.Font.init(Size: 20))
                         ),
-                        Chart.Invisible(),
-                        Chart.Invisible(),
-                        Chart.Invisible(),
-                        Chart.Invisible(),
+                        Chart.Combine(
+                            new GenericChart []
+                            {
+                                Chart.ScatterMapbox<int,int,string>(
+                                    longitudes: new int [] { 1, 20 },
+                                    latitudes: new int [] { 1, 40 },
+                                    mode: Mode.Markers,
+                                    Name: "scattermapbox"
+                                )
+                                //Chart.PointMapbox<int,int,string>(
+                                //    longitudes: new int [] { 40, 50 },
+                                //    latitudes: new int [] { 60, 70 },
+                                //    Name: "pointgeo"
+                                //),
+                                //Chart.LineMapbox<int,int,string>(
+                                //    longitudes: new int [] { 10,  -100},
+                                //    latitudes: new int [] { 50, 50 },
+                                //    Name: "linemapbox"
+                                //),
+                                //Chart.BubbleMapbox<int,int,string>(
+                                //    longitudes: new int [] { 80,  -80},
+                                //    latitudes: new int [] { 20, -20 },
+                                //    sizes: new int [] { 10, 20 },
+                                //    Name: "bubblemapbox"
+                                //),
+                            }
+                        ).WithMaboxStyle(
+                            Style: MapboxStyle.OpenStreetMap,
+                            Id: 38
+                        ).WithTraceInfo(
+                            LegendGroup: "scattermapbox-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattermapbox derived traces", Font: Plotly.NET.Font.init(Size: 20))
+                        ),
                         Chart.DensityMapbox<int,int,int,string>(
                             longitudes: new int [] { 1,2,2,2,3,4,5,5 },
                             latitudes:  new int [] { 1,2,2,2,3,4,5,5 },
                             ShowScale: false
                         ).WithMaboxStyle(
-                            Style: MapboxStyle.OpenStreetMap
+                            Style: MapboxStyle.OpenStreetMap,
+                            Id: 39
+                        ).WithTraceInfo(
+                            LegendGroup: "other-mapbox",
+                            LegendGroupTitle: Plotly.NET.Title.init("other mapbox charts", Font: Plotly.NET.Font.init(Size: 20))
                         ),
+                        Chart.Invisible(),
+                        Chart.Invisible(),
+                        Chart.Invisible(),
 
                         //ternary traces
                         Chart.ScatterTernary<int,int,int,IConvertible,string>(

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -469,21 +469,21 @@ namespace TestConsoleApp
                             new GenericChart []
                             {
                                 Chart.ScatterMapbox<int,int,string>(
-                                    longitudes: new int [] { 1, 20 },
-                                    latitudes: new int [] { 1, 40 },
+                                    longitudes: new int [] { 1, 2 },
+                                    latitudes: new int [] { 1, 2 },
                                     mode: Mode.Markers,
                                     Name: "scattermapbox"
-                                )
-                                //Chart.PointMapbox<int,int,string>(
-                                //    longitudes: new int [] { 40, 50 },
-                                //    latitudes: new int [] { 60, 70 },
-                                //    Name: "pointgeo"
-                                //),
-                                //Chart.LineMapbox<int,int,string>(
-                                //    longitudes: new int [] { 10,  -100},
-                                //    latitudes: new int [] { 50, 50 },
-                                //    Name: "linemapbox"
-                                //),
+                                ),
+                                Chart.PointMapbox<int,int,string>(
+                                    longitudes: new int [] { 10, 11 },
+                                    latitudes: new int [] { 10, 11 },
+                                    Name: "pointmapbox"
+                                ),
+                                Chart.LineMapbox<int,int,string>(
+                                    longitudes: new int [] { -1, 11},
+                                    latitudes: new int [] { 11, 1 },
+                                    Name: "linemapbox"
+                                ),
                                 //Chart.BubbleMapbox<int,int,string>(
                                 //    longitudes: new int [] { 80,  -80},
                                 //    latitudes: new int [] { 20, -20 },

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -424,12 +424,17 @@ namespace TestConsoleApp
                         Chart.Invisible(),
 
                         //geo/mapbox traces
+                        Chart.ChoroplethMap<int, string>(
+                            locations: new string [] {"USA", "Germany", "Australia"},
+                            z: new int [] {1, 2, 3},
+                            LocationMode: LocationFormat.CountryNames
+                        ),
+
                         Chart.ScatterGeo<int,int,string>(
                             longitudes: new int [] { 1, 2 },
                             latitudes: new int [] { 3, 4 },
                             mode: Mode.Markers
                         ),
-                        Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -442,6 +442,12 @@ namespace TestConsoleApp
                                     longitudes: new int [] { 10,  -100},
                                     latitudes: new int [] { 50, 50 },
                                     Name: "linegeo"
+                                ),                                
+                                Chart.BubbleGeo<int,int,string>(
+                                    longitudes: new int [] { 80,  -80},
+                                    latitudes: new int [] { 20, -20 },
+                                    sizes: new int [] { 10, 20 },
+                                    Name: "bubblegeo"
                                 ),
                             }
                         ).WithTraceInfo(

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -424,16 +424,35 @@ namespace TestConsoleApp
                         Chart.Invisible(),
 
                         //geo/mapbox traces
+                        Chart.Combine(
+                            new GenericChart []
+                            {
+                                Chart.ScatterGeo<int,int,string>(
+                                    longitudes: new int [] { 1, 20 },
+                                    latitudes: new int [] { 1, 40 },
+                                    mode: Mode.Markers,
+                                    Name: "scattergeo"
+                                ),
+                                Chart.PointGeo<int,int,string>(
+                                    longitudes: new int [] { 40, 50 },
+                                    latitudes: new int [] { 60, 70 },
+                                    Name: "pointgeo"
+                                ),
+                            }
+                        ).WithTraceInfo(
+                            LegendGroup: "scattergeo-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattergeo derived traces", Font: Plotly.NET.Font.init(Size: 20))
+                        ),
                         Chart.ChoroplethMap<int, string>(
                             locations: new string [] {"USA", "Germany", "Australia"},
                             z: new int [] {1, 2, 3},
-                            LocationMode: LocationFormat.CountryNames
-                        ),
-
-                        Chart.ScatterGeo<int,int,string>(
-                            longitudes: new int [] { 1, 2 },
-                            latitudes: new int [] { 3, 4 },
-                            mode: Mode.Markers
+                            LocationMode: LocationFormat.CountryNames,
+                            ShowScale: false,
+                            ShowLegend: true,
+                            Name: "choropleth"
+                        ).WithTraceInfo(
+                            LegendGroup: "other-geo",
+                            LegendGroupTitle: Plotly.NET.Title.init("other geo charts", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -437,6 +437,11 @@ namespace TestConsoleApp
                                     longitudes: new int [] { 40, 50 },
                                     latitudes: new int [] { 60, 70 },
                                     Name: "pointgeo"
+                                ),                                
+                                Chart.LineGeo<int,int,string>(
+                                    longitudes: new int [] { 10,  -100},
+                                    latitudes: new int [] { 50, 50 },
+                                    Name: "linegeo"
                                 ),
                             }
                         ).WithTraceInfo(


### PR DESCRIPTION
This PR adds C# bindings for the rest of the map-related charts:
- [x] ChoroplethMap
- [x] PointGeo
- [x] LineGeo
- [x] BubbleGeo
- [x] ScatterMapbox
- [x] LineMapbox
- [x] BubbleMapbox
- [x] ChoroplethMapbox

The compatibility matrix now looks like this:

![image](https://user-images.githubusercontent.com/21338071/185623248-d757d464-af7a-426e-bc5e-43873d91a513.png)
