### PR TITLE
[C#] add C# bindings for the missing ternary and carpet charts 

### DIFF
--- a/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
@@ -181,6 +181,75 @@ namespace Plotly.NET.CSharp
                 UseDefaults: UseDefaults.ToOption()
             );
 
+        /// <summary>
+        /// Creates a point plot that lies on a specified carpet.
+        ///
+        /// In general, PointCarpet creates a point plot that uses the given carpet identifier as coordinate system.
+        ///
+        /// Wether the resulting plot is a cheater or true carpet plot depends on the referenced carpet.
+        /// </summary>
+        /// <param name="a">Sets the a-axis coordinates on the carpet.</param>
+        /// <param name="b">Sets the b-axis coordinates on the carpet.</param>
+        /// <param name="carpetAnchorId">The identifier of the carpet that this trace will lie on.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart PointCarpet<AType, BType, TextType>(
+            IEnumerable<AType> a,
+            IEnumerable<BType> b,
+            string carpetAnchorId,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<bool> UseDefaults = default
+        )
+            where AType : IConvertible
+            where BType : IConvertible
+            where TextType : IConvertible
+        =>
+            Plotly.NET.ChartCarpet.Chart.PointCarpet<AType, BType, TextType>(
+                a: a,
+                b: b,
+                carpetAnchorId: carpetAnchorId,
+                Name: Name.ToOption(),
+                ShowLegend: ShowLegend.ToOption(),
+                Opacity: Opacity.ToOption(),
+                MultiOpacity: MultiOpacity.ToOption(),
+                Text: Text.ToOption(),
+                MultiText: MultiText.ToOption(),
+                TextPosition: TextPosition.ToOption(),
+                MultiTextPosition: MultiTextPosition.ToOption(),
+                MarkerColor: MarkerColor.ToOption(),
+                MarkerColorScale: MarkerColorScale.ToOption(),
+                MarkerOutline: MarkerOutline.ToOption(),
+                MarkerSymbol: MarkerSymbol.ToOption(),
+                MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                Marker: Marker.ToOption(),
+                UseDefaults: UseDefaults.ToOption()
+            );
 
         /// <summary>
         /// Creates a contour chart that lies on a specified carpet.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
@@ -431,6 +431,95 @@ namespace Plotly.NET.CSharp
                 UseDefaults: UseDefaults.ToOption()
             );
 
+        /// <summary>
+        /// Creates a bubble chart that lies on a specified carpet.
+        ///
+        /// In general, BubbleCarpet creates a bubble chart that uses the given carpet identifier as coordinate system.
+        ///
+        /// A bubble chart is a variation of the Point chart, where the data points get an additional scale by being rendered as bubbles of different sizes.
+        ///
+        /// Wether the resulting plot is a cheater or true carpet plot depends on the referenced carpet.
+        /// </summary>
+        /// <param name="a">Sets the a-axis coordinates on the carpet.</param>
+        /// <param name="b">Sets the b-axis coordinates on the carpet.</param>
+        /// <param name="sizes">Sets the bubble size of the plotted data</param>
+        /// <param name="carpetAnchorId">The identifier of the carpet that this trace will lie on.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart BubbleCarpet<AType, BType, TextType>(
+            IEnumerable<AType> a,
+            IEnumerable<BType> b,
+            IEnumerable<int> sizes,
+            string carpetAnchorId,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<bool> UseDefaults = default
+        )
+            where AType : IConvertible
+            where BType : IConvertible
+            where TextType : IConvertible
+        =>
+            Plotly.NET.ChartCarpet.Chart.BubbleCarpet<AType, BType, TextType>(
+                a: a,
+                b: b,
+                sizes: sizes,
+                carpetAnchorId: carpetAnchorId,
+                Name: Name.ToOption(),
+                ShowLegend: ShowLegend.ToOption(),
+                Opacity: Opacity.ToOption(),
+                MultiOpacity: MultiOpacity.ToOption(),
+                Text: Text.ToOption(),
+                MultiText: MultiText.ToOption(),
+                TextPosition: TextPosition.ToOption(),
+                MultiTextPosition: MultiTextPosition.ToOption(),
+                MarkerColor: MarkerColor.ToOption(),
+                MarkerColorScale: MarkerColorScale.ToOption(),
+                MarkerOutline: MarkerOutline.ToOption(),
+                MarkerSymbol: MarkerSymbol.ToOption(),
+                MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                Marker: Marker.ToOption(),
+                LineColor: LineColor.ToOption(),
+                LineColorScale: LineColorScale.ToOption(),
+                LineWidth: LineWidth.ToOption(),
+                LineDash: LineDash.ToOption(),
+                Line: Line.ToOption(),
+                UseDefaults: UseDefaults.ToOption()
+            );
 
         /// <summary>
         /// Creates a contour chart that lies on a specified carpet.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
@@ -92,6 +92,97 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a scatter plot that lies on a specified carpet.
+        ///
+        /// In general, ScatterCarpet creates a plot that uses the given carpet identifier as coordinate system.
+        ///
+        /// Wether the resulting plot is a cheater or true carpet plot depends on the referenced carpet.
+        ///
+        /// ScatterCarpet charts are the basis of PointCarpet, LineCarpet, and BubbleCarpet Charts, and can be customized as such. We also provide abstractions for those: Chart.LineCarpet, Chart.PointCarpet, Chart.BubbleCarpet
+        /// </summary>
+        /// <param name="a">Sets the a-axis coordinates on the carpet.</param>
+        /// <param name="b">Sets the b-axis coordinates on the carpet.</param>
+        /// <param name="mode">Determines the drawing mode for this scatter trace. If the provided `mode` includes "text" then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points and the trace is not stacked then the default is "lines+markers". Otherwise, "lines".</param>
+        /// <param name="carpetAnchorId">The identifier of the carpet that this trace will lie on.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart ScatterCarpet<AType, BType, TextType>(
+            IEnumerable<AType> a,
+            IEnumerable<BType> b,
+            StyleParam.Mode mode,
+            string carpetAnchorId,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<bool> UseDefaults = default
+        )
+            where AType : IConvertible
+            where BType : IConvertible
+            where TextType : IConvertible
+        =>
+            Plotly.NET.ChartCarpet.Chart.ScatterCarpet<AType, BType, TextType>(
+                a: a,
+                b: b,
+                mode: mode,
+                carpetAnchorId: carpetAnchorId,
+                Name: Name.ToOption(),
+                ShowLegend: ShowLegend.ToOption(),
+                Opacity: Opacity.ToOption(),
+                MultiOpacity: MultiOpacity.ToOption(),
+                Text: Text.ToOption(),
+                MultiText: MultiText.ToOption(),
+                TextPosition: TextPosition.ToOption(),
+                MultiTextPosition: MultiTextPosition.ToOption(),
+                MarkerColor: MarkerColor.ToOption(),
+                MarkerColorScale: MarkerColorScale.ToOption(),
+                MarkerOutline: MarkerOutline.ToOption(),
+                MarkerSymbol: MarkerSymbol.ToOption(),
+                MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                Marker: Marker.ToOption(),
+                LineColor: LineColor.ToOption(),
+                LineColorScale: LineColorScale.ToOption(),
+                LineWidth: LineWidth.ToOption(),
+                LineDash: LineDash.ToOption(),
+                Line: Line.ToOption(),
+                UseDefaults: UseDefaults.ToOption()
+            );
+
+
+        /// <summary>
         /// Creates a contour chart that lies on a specified carpet.
         ///
         /// Plots contours on either the first carpet axis or the carpet axis with a matching `carpet` attribute. Data `z` is interpreted as matching that of the corresponding carpet axis.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
@@ -252,6 +252,95 @@ namespace Plotly.NET.CSharp
             );
 
         /// <summary>
+        /// Creates a line plot that lies on a specified carpet.
+        ///
+        /// In general, LineCarpet creates a line plot that uses the given carpet identifier as coordinate system.
+        ///
+        /// Wether the resulting plot is a cheater or true carpet plot depends on the referenced carpet.
+        /// </summary>
+        /// <param name="a">Sets the a-axis coordinates on the carpet.</param>
+        /// <param name="b">Sets the b-axis coordinates on the carpet.</param>
+        /// <param name="carpetAnchorId">The identifier of the carpet that this trace will lie on.</param>
+        /// <param name="ShowMarkers">Wether to show markers for the individual data points</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart LineCarpet<AType, BType, TextType>(
+            IEnumerable<AType> a,
+            IEnumerable<BType> b,
+            string carpetAnchorId,
+            Optional<bool> ShowMarkers = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<bool> UseDefaults = default
+        )
+            where AType : IConvertible
+            where BType : IConvertible
+            where TextType : IConvertible
+        =>
+            Plotly.NET.ChartCarpet.Chart.LineCarpet<AType, BType, TextType>(
+                a: a,
+                b: b,
+                carpetAnchorId: carpetAnchorId,
+                ShowMarkers: ShowMarkers.ToOption(),
+                Name: Name.ToOption(),
+                ShowLegend: ShowLegend.ToOption(),
+                Opacity: Opacity.ToOption(),
+                MultiOpacity: MultiOpacity.ToOption(),
+                Text: Text.ToOption(),
+                MultiText: MultiText.ToOption(),
+                TextPosition: TextPosition.ToOption(),
+                MultiTextPosition: MultiTextPosition.ToOption(),
+                MarkerColor: MarkerColor.ToOption(),
+                MarkerColorScale: MarkerColorScale.ToOption(),
+                MarkerOutline: MarkerOutline.ToOption(),
+                MarkerSymbol: MarkerSymbol.ToOption(),
+                MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                Marker: Marker.ToOption(),
+                LineColor: LineColor.ToOption(),
+                LineColorScale: LineColorScale.ToOption(),
+                LineWidth: LineWidth.ToOption(),
+                LineDash: LineDash.ToOption(),
+                Line: Line.ToOption(),
+                UseDefaults: UseDefaults.ToOption()
+            );
+
+
+        /// <summary>
         /// Creates a contour chart that lies on a specified carpet.
         ///
         /// Plots contours on either the first carpet axis or the carpet axis with a matching `carpet` attribute. Data `z` is interpreted as matching that of the corresponding carpet axis.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartCarpet.cs
@@ -339,6 +339,98 @@ namespace Plotly.NET.CSharp
                 UseDefaults: UseDefaults.ToOption()
             );
 
+        /// <summary>
+        /// Creates a spline plot that lies on a specified carpet.
+        ///
+        /// In general, SplineCarpet creates a spline plot that uses the given carpet identifier as coordinate system.
+        /// A spline chart is a line chart in which data points are connected by smoothed curves.
+        ///
+        /// Wether the resulting plot is a cheater or true carpet plot depends on the referenced carpet.
+        /// </summary>
+        /// <param name="a">Sets the a-axis coordinates on the carpet.</param>
+        /// <param name="b">Sets the b-axis coordinates on the carpet.</param>
+        /// <param name="carpetAnchorId">The identifier of the carpet that this trace will lie on.</param>
+        /// <param name="ShowMarkers">Wether to show markers for the individual data points</param>
+        /// <param name="Smoothing">Sets the amount of smoothing. "0" corresponds to no smoothing (equivalent to a "linear" shape).  Use values between 0. and 1.3</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart SplineCarpet<AType, BType, TextType>(
+            IEnumerable<AType> a,
+            IEnumerable<BType> b,
+            string carpetAnchorId,
+            Optional<bool> ShowMarkers = default,
+            Optional<double> Smoothing = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<bool> UseDefaults = default
+        )
+            where AType : IConvertible
+            where BType : IConvertible
+            where TextType : IConvertible
+        =>
+            Plotly.NET.ChartCarpet.Chart.SplineCarpet<AType, BType, TextType>(
+                a: a,
+                b: b,
+                carpetAnchorId: carpetAnchorId,
+                ShowMarkers: ShowMarkers.ToOption(),
+                Smoothing: Smoothing.ToOption(),
+                Name: Name.ToOption(),
+                ShowLegend: ShowLegend.ToOption(),
+                Opacity: Opacity.ToOption(),
+                MultiOpacity: MultiOpacity.ToOption(),
+                Text: Text.ToOption(),
+                MultiText: MultiText.ToOption(),
+                TextPosition: TextPosition.ToOption(),
+                MultiTextPosition: MultiTextPosition.ToOption(),
+                MarkerColor: MarkerColor.ToOption(),
+                MarkerColorScale: MarkerColorScale.ToOption(),
+                MarkerOutline: MarkerOutline.ToOption(),
+                MarkerSymbol: MarkerSymbol.ToOption(),
+                MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                Marker: Marker.ToOption(),
+                LineColor: LineColor.ToOption(),
+                LineColorScale: LineColorScale.ToOption(),
+                LineWidth: LineWidth.ToOption(),
+                LineDash: LineDash.ToOption(),
+                Line: Line.ToOption(),
+                UseDefaults: UseDefaults.ToOption()
+            );
+
 
         /// <summary>
         /// Creates a contour chart that lies on a specified carpet.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartTernary.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartTernary.cs
@@ -267,5 +267,99 @@ namespace Plotly.NET.CSharp
                     Line: Line.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+
+        /// <summary>
+        /// Creates a bubble plot on a ternary coordinate system
+        ///
+        /// A bubble chart is a variation of the Point chart, where the data points get an additional scale by being rendered as bubbles of different sizes.
+        ///
+        /// In general, BubbleTernary creates a barycentric point plot on three variables which sum to a constant, graphically depicting the ratios of the three variables as positions in an equilateral triangle.
+        /// A 4th data dimension is used to determine the size of the points.
+        /// </summary>
+        /// <param name="sizes">Sets the bubble size of the plotted data</param>
+        /// <param name="A">Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="B">Sets the quantity of component `b` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="C">Sets the quantity of component `c` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="Sum">The number each triplet should sum to, if only two of `a`, `b`, and `c` are provided. This overrides `ternary&lt;i&gt;.sum` to normalize this specific trace, but does not affect the values displayed on the axes. 0 (or missing) means to use `ternary&lt;i&gt;.sum`</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart BubbleTernary<AType, BType, CType, SumType, TextType>(
+            IEnumerable<int> sizes,
+            Optional<IEnumerable<AType>> A = default,
+            Optional<IEnumerable<BType>> B = default,
+            Optional<IEnumerable<CType>> C = default,
+            Optional<SumType> Sum = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<bool> UseDefaults = default
+        )
+            where AType : IConvertible
+            where BType : IConvertible
+            where CType : IConvertible
+            where SumType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartTernary.Chart.BubbleTernary<AType, BType, CType, SumType, TextType>(
+                    sizes: sizes,
+                    A: A.ToOption(),
+                    B: B.ToOption(),
+                    C: C.ToOption(),
+                    Sum: Sum.ToOption(),
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    LineWidth: LineWidth.ToOption(),
+                    LineDash: LineDash.ToOption(),
+                    Line: Line.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
     }
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartTernary.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartTernary.cs
@@ -103,5 +103,169 @@ namespace Plotly.NET.CSharp
                     Line: Line.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+
+        /// <summary>
+        /// Creates a point plot on a ternary coordinate system
+        ///
+        /// In general, PointTernary creates a barycentric point plot on three variables which sum to a constant, graphically depicting the ratios of the three variables as positions in an equilateral triangle.
+        /// </summary>
+        /// <param name="A">Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="B">Sets the quantity of component `b` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="C">Sets the quantity of component `c` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="Sum">The number each triplet should sum to, if only two of `a`, `b`, and `c` are provided. This overrides `ternary&lt;i&gt;.sum` to normalize this specific trace, but does not affect the values displayed on the axes. 0 (or missing) means to use `ternary&lt;i&gt;.sum`</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart PointTernary<AType, BType, CType, SumType, TextType>(
+            Optional<IEnumerable<AType>> A = default,
+            Optional<IEnumerable<BType>> B = default,
+            Optional<IEnumerable<CType>> C = default,
+            Optional<SumType> Sum = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<bool> UseDefaults = default
+        )
+            where AType : IConvertible
+            where BType : IConvertible
+            where CType : IConvertible
+            where SumType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartTernary.Chart.PointTernary<AType, BType, CType, SumType, TextType>(
+                    A: A.ToOption(),
+                    B: B.ToOption(),
+                    C: C.ToOption(),
+                    Sum: Sum.ToOption(),
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
+        /// Creates a line plot on a ternary coordinate system
+        ///
+        /// In general, LineTernary creates a barycentric line plot on three variables which sum to a constant, graphically depicting the ratios of the three variables as positions in an equilateral triangle.
+        /// </summary>
+        /// <param name="A">Sets the quantity of component `a` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="B">Sets the quantity of component `b` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="C">Sets the quantity of component `c` in each data point. If `a`, `b`, and `c` are all provided, they need not be normalized, only the relative values matter. If only two arrays are provided they must be normalized to match `ternary&lt;i&gt;.sum`.</param>
+        /// <param name="Sum">The number each triplet should sum to, if only two of `a`, `b`, and `c` are provided. This overrides `ternary&lt;i&gt;.sum` to normalize this specific trace, but does not affect the values displayed on the axes. 0 (or missing) means to use `ternary&lt;i&gt;.sum`</param>
+        /// <param name="ShowMarkers">Wether to show markers for the individual data points</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart LineTernary<AType, BType, CType, SumType, TextType>(
+            Optional<IEnumerable<AType>> A = default,
+            Optional<IEnumerable<BType>> B = default,
+            Optional<IEnumerable<CType>> C = default,
+            Optional<SumType> Sum = default,
+            Optional<bool> ShowMarkers = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<bool> UseDefaults = default
+        )
+            where AType : IConvertible
+            where BType : IConvertible
+            where CType : IConvertible
+            where SumType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartTernary.Chart.LineTernary<AType, BType, CType, SumType, TextType>(
+                    A: A.ToOption(),
+                    B: B.ToOption(),
+                    C: C.ToOption(),
+                    Sum: Sum.ToOption(),
+                    ShowMarkers: ShowMarkers.ToOption(),
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    LineWidth: LineWidth.ToOption(),
+                    LineDash: LineDash.ToOption(),
+                    Line: Line.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
     }
 }

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -610,6 +610,9 @@ namespace TestConsoleApp
                                     Name: "scattercarpet"
                                 )
                             }
+                        ).WithTraceInfo(
+                            LegendGroup: "scattercarpet-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattercarpet derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.Combine(
                             new GenericChart []
@@ -627,6 +630,9 @@ namespace TestConsoleApp
                                     Name: "pointcarpet"
                                 )
                             }
+                        ).WithTraceInfo(
+                            LegendGroup: "scattercarpet-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattercarpet derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.Combine(
                             new GenericChart []
@@ -644,6 +650,9 @@ namespace TestConsoleApp
                                     Name: "linecarpet"
                                 )
                             }
+                        ).WithTraceInfo(
+                            LegendGroup: "scattercarpet-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattercarpet derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.Combine(
                             new GenericChart []
@@ -658,16 +667,39 @@ namespace TestConsoleApp
                                     a: new int [] {4,5,5,6},
                                     b: new int [] {1,1,2,3},
                                     carpetAnchorId: "carpet5",
-                                    Name: "linecarpet"
+                                    Name: "splinecarpet"
                                 )
                             }
+                        ).WithTraceInfo(
+                            LegendGroup: "scattercarpet-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattercarpet derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
-                        Chart.Invisible(),
                         Chart.Combine(
                             new GenericChart []
                             {
                                 Chart.Carpet<double,double,double,double,double,double>(
-                                    carpetId: "contour",
+                                    carpetId: "carpet6",
+                                    A: new double [] {4.0, 4.0, 4.0, 4.5, 4.5, 4.5, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0},
+                                    B: new double [] {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0},
+                                    Y: new double [] {2.0, 3.5, 4.0, 3.0, 4.5, 5.0, 5.5, 6.5, 7.5, 8.0, 8.5, 10.0}
+                                ),
+                                Chart.BubbleCarpet<int, int, string>(
+                                    sizes: new int [] {10, 20, 30, 40},
+                                    a: new int [] {4,5,5,6},
+                                    b: new int [] {1,1,2,3},
+                                    carpetAnchorId: "carpet6",
+                                    Name: "bubblecarpet"
+                                )
+                            }
+                        ).WithTraceInfo(
+                            LegendGroup: "scattercarpet-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattercarpet derived traces", Font: Plotly.NET.Font.init(Size: 20))
+                        ),
+                        Chart.Combine(
+                            new GenericChart []
+                            {
+                                Chart.Carpet<double,double,double,double,double,double>(
+                                    carpetId: "carpet7",
                                     A: new double [] { 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0},
                                     B: new double[] { 4.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0, 6.0},
                                     X: new double[] { 2.0, 3.0, 4.0, 5.0, 2.2, 3.1, 4.1, 5.1, 1.5, 2.5, 3.5, 4.5},
@@ -675,12 +707,17 @@ namespace TestConsoleApp
                                 ),
                                 Chart.ContourCarpet<double,int,int,string>(
                                     z: new double [] { 1.0, 1.96, 2.56, 3.0625, 4.0, 5.0625, 1.0, 7.5625, 9.0, 12.25, 15.21, 14.0625 },
-                                    carpetAnchorId: "contour",
+                                    carpetAnchorId: "carpet7",
                                     A: new int [] { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
                                     B: new int[] { 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6},
-                                    ShowScale: false
+                                    ShowScale: false,
+                                    ShowLegend: true,
+                                    Name: "contourcarpet"
                                 )
                             }
+                        ).WithTraceInfo(
+                            LegendGroup: "carpet-other",
+                            LegendGroupTitle: Plotly.NET.Title.init("other carpet traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
 
                         //domain traces

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -645,7 +645,23 @@ namespace TestConsoleApp
                                 )
                             }
                         ),
-                        Chart.Invisible(),
+                        Chart.Combine(
+                            new GenericChart []
+                            {
+                                Chart.Carpet<double,double,double,double,double,double>(
+                                    carpetId: "carpet5",
+                                    A: new double [] {4.0, 4.0, 4.0, 4.5, 4.5, 4.5, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0},
+                                    B: new double [] {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0},
+                                    Y: new double [] {2.0, 3.5, 4.0, 3.0, 4.5, 5.0, 5.5, 6.5, 7.5, 8.0, 8.5, 10.0}
+                                ),
+                                Chart.SplineCarpet<int, int, string>(
+                                    a: new int [] {4,5,5,6},
+                                    b: new int [] {1,1,2,3},
+                                    carpetAnchorId: "carpet5",
+                                    Name: "linecarpet"
+                                )
+                            }
+                        ),
                         Chart.Invisible(),
                         Chart.Combine(
                             new GenericChart []

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -519,8 +519,16 @@ namespace TestConsoleApp
                             B: new int [] { 3, 4 },
                             C: new int [] { 5, 6 }
                         ),
-                        Chart.Invisible(),
-                        Chart.Invisible(),
+                        Chart.PointTernary<int,int,int,int,string>(
+                            A: new int [] { 1, 2 },
+                            B: new int [] { 3, 4 },
+                            C: new int [] { 5, 6 }
+                        ),
+                        Chart.LineTernary<int,int,int,int,string>(
+                            A: new int [] { 1, 2 },
+                            B: new int [] { 3, 4 },
+                            C: new int [] { 10, 2 }
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -236,21 +236,29 @@ namespace TestConsoleApp
                             high: new double [] {1.8, 8.5},
                             low: new double []  {0.5, 0.1},
                             close: new double [] {1.1, 2.9},
-                            x: new DateTime [] {DateTime.Parse("07/07/2021"), DateTime.Parse("07/07/2022") }
+                            x: new DateTime [] {DateTime.Parse("07/07/2021"), DateTime.Parse("07/07/2022") },
+                            Name: "ohlc"
                         ).WithXAxisRangeSlider(
                             rangeSlider: Plotly.NET.LayoutObjects.RangeSlider.init(
-                                Visible: false
-                        )),
+                            Visible: false
+                        )).WithTraceInfo(
+                            LegendGroup: "finance",
+                            LegendGroupTitle: Plotly.NET.Title.init("finance charts", Font: Plotly.NET.Font.init(Size: 20))
+                        ),
                         Chart.Candlestick<double,DateTime,string>(
                             open: new double [] {1.2, 2.7},
                             high: new double [] {1.8, 8.5},
                             low: new double []  {0.5, 0.1},
                             close: new double [] {1.1, 2.9},
-                            x: new DateTime [] {DateTime.Parse("07/07/2021"), DateTime.Parse("07/07/2022") }
+                            x: new DateTime [] {DateTime.Parse("07/07/2021"), DateTime.Parse("07/07/2022") },
+                            Name: "candlestick"
                         ).WithXAxisRangeSlider(
                             rangeSlider: Plotly.NET.LayoutObjects.RangeSlider.init(
                                 Visible: false
-                        )),
+                        )).WithTraceInfo(
+                            LegendGroup: "finance",
+                            LegendGroupTitle: Plotly.NET.Title.init("finance charts", Font: Plotly.NET.Font.init(Size: 20))
+                        ),
                         Chart.Waterfall<string, int, string>(
                             x: new string [] {"A", "B", "Net", "Purch", "Other", "Profit"},
                             y: new int [] {60, 80, 0, -40, -20, 0},
@@ -261,33 +269,54 @@ namespace TestConsoleApp
                                 Plotly.NET.StyleParam.WaterfallMeasure.Relative,
                                 Plotly.NET.StyleParam.WaterfallMeasure.Relative,
                                 Plotly.NET.StyleParam.WaterfallMeasure.Total
-                            }
+                            },
+                            Name: "waterfall"
+                        ).WithTraceInfo(
+                            LegendGroup: "finance",
+                            LegendGroupTitle: Plotly.NET.Title.init("finance charts", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.Funnel<double, string, string>(
                             x: new double [] { 1200, 909.4, 600.6, 300, 80 },
-                            y: new string[] { "A", "B", "C", "D", "E"}
+                            y: new string[] { "A", "B", "C", "D", "E"},
+                            Name: "funnel"
+                        ).WithTraceInfo(
+                            LegendGroup: "finance",
+                            LegendGroupTitle: Plotly.NET.Title.init("finance charts", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.Combine(
                             new GenericChart []
                             {
                                 Chart.StackedFunnel<double, string, string>(
-                                    x: new double [] { 1200, 909.4, 600.6, 300, 80 },
-                                    y: new string[] { "A", "B", "C", "D", "E"}
+                                    x: new double [] { 1200, 909.4},
+                                    y: new string[] { "A", "B"},
+                                    Name: "stackedfunnel 1"
                                 ),
                                 Chart.StackedFunnel<double, string, string>(
-                                    x: new double [] { 1200, 909.4, 600.6, 300, 80 },
-                                    y: new string[] { "A", "B", "C", "D", "E"}
+                                    x: new double [] { 1200, 100.4,},
+                                    y: new string[] { "A", "B"},
+                                    Name: "stackedfunnel 2"
                                 ),
                             }
+                        ).WithTraceInfo(
+                            LegendGroup: "finance",
+                            LegendGroupTitle: Plotly.NET.Title.init("finance charts", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.FunnelArea<int, string, string>(
-                            values: new int [] { 5, 4, 3, 2, 1 },
-                            MultiText: new string[] { "A", "B", "C", "D", "E"}
+                            values: new int [] { 5, 4},
+                            MultiText: new string[] { "A", "B"},
+                            Name: "funnelarea"
+                        ).WithTraceInfo(
+                            LegendGroup: "finance",
+                            LegendGroupTitle: Plotly.NET.Title.init("finance charts", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.Indicator<double>(
                             value: 200,
                             mode: Plotly.NET.StyleParam.IndicatorMode.NumberDeltaGauge,
-                            DeltaReference: 160
+                            DeltaReference: 160,
+                            Name: "indicator"
+                        ).WithTraceInfo(
+                            LegendGroup: "finance",
+                            LegendGroupTitle: Plotly.NET.Title.init("finance charts", Font: Plotly.NET.Font.init(Size: 20))
                         ),
 
                         //3D traces
@@ -517,19 +546,40 @@ namespace TestConsoleApp
                         Chart.ScatterTernary<int,int,int,IConvertible,string>(
                             A: new int [] { 1, 2 },
                             B: new int [] { 3, 4 },
-                            C: new int [] { 5, 6 }
+                            C: new int [] { 10, 2 },
+                            Name: "scatterternary"
+                        ).WithTraceInfo(
+                            LegendGroup: "scatterternary-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scatterternary derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.PointTernary<int,int,int,int,string>(
                             A: new int [] { 1, 2 },
                             B: new int [] { 3, 4 },
-                            C: new int [] { 5, 6 }
+                            C: new int [] { 10, 2 },
+                            Name: "pointternary"
+                        ).WithTraceInfo(
+                            LegendGroup: "scatterternary-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scatterternary derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.LineTernary<int,int,int,int,string>(
                             A: new int [] { 1, 2 },
                             B: new int [] { 3, 4 },
-                            C: new int [] { 10, 2 }
+                            C: new int [] { 10, 2 },
+                            Name: "lineternary"
+                        ).WithTraceInfo(
+                            LegendGroup: "scatterternary-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scatterternary derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
-                        Chart.Invisible(),
+                        Chart.BubbleTernary<int,int,int,int,string>(
+                            sizes: new int [] {30, 40},
+                            A: new int [] { 1, 2 },
+                            B: new int [] { 3, 4 },
+                            C: new int [] { 10, 2 },
+                            Name: "bubbleternary"
+                        ).WithTraceInfo(
+                            LegendGroup: "scatterternary-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scatterternary derived traces", Font: Plotly.NET.Font.init(Size: 20))
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -586,12 +586,31 @@ namespace TestConsoleApp
 
                         //carpet traces
                         Chart.Carpet<double,double,double,double,double,double>(
-                            carpetId: "testCarpet",
+                            carpetId: "carpet1",
                             A: new double [] {4.0, 4.0, 4.0, 4.5, 4.5, 4.5, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0},
                             B: new double [] {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0},
-                            Y: new double [] {2.0, 3.5, 4.0, 3.0, 4.5, 5.0, 5.5, 6.5, 7.5, 8.0, 8.5, 10.0}
+                            Y: new double [] {2.0, 3.5, 4.0, 3.0, 4.5, 5.0, 5.5, 6.5, 7.5, 8.0, 8.5, 10.0},
+                            Name:"carpet",
+                            ShowLegend: true
                         ),
-                        Chart.Invisible(),
+                        Chart.Combine(
+                            new GenericChart []
+                            {
+                                Chart.Carpet<double,double,double,double,double,double>(
+                                    carpetId: "carpet2",
+                                    A: new double [] {4.0, 4.0, 4.0, 4.5, 4.5, 4.5, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0},
+                                    B: new double [] {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0},
+                                    Y: new double [] {2.0, 3.5, 4.0, 3.0, 4.5, 5.0, 5.5, 6.5, 7.5, 8.0, 8.5, 10.0}
+                                ),
+                                Chart.ScatterCarpet<int, int, string>(
+                                    a: new int [] {4,5,5,6},
+                                    b: new int [] {1,1,2,3},
+                                    carpetAnchorId: "carpet2",
+                                    mode: Mode.Markers,
+                                    Name: "scattercarpet"
+                                )
+                            }
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -611,7 +611,23 @@ namespace TestConsoleApp
                                 )
                             }
                         ),
-                        Chart.Invisible(),
+                        Chart.Combine(
+                            new GenericChart []
+                            {
+                                Chart.Carpet<double,double,double,double,double,double>(
+                                    carpetId: "carpet3",
+                                    A: new double [] {4.0, 4.0, 4.0, 4.5, 4.5, 4.5, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0},
+                                    B: new double [] {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0},
+                                    Y: new double [] {2.0, 3.5, 4.0, 3.0, 4.5, 5.0, 5.5, 6.5, 7.5, 8.0, 8.5, 10.0}
+                                ),
+                                Chart.PointCarpet<int, int, string>(
+                                    a: new int [] {4,5,5,6},
+                                    b: new int [] {1,1,2,3},
+                                    carpetAnchorId: "carpet3",
+                                    Name: "pointcarpet"
+                                )
+                            }
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -628,7 +628,23 @@ namespace TestConsoleApp
                                 )
                             }
                         ),
-                        Chart.Invisible(),
+                        Chart.Combine(
+                            new GenericChart []
+                            {
+                                Chart.Carpet<double,double,double,double,double,double>(
+                                    carpetId: "carpet4",
+                                    A: new double [] {4.0, 4.0, 4.0, 4.5, 4.5, 4.5, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0},
+                                    B: new double [] {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0},
+                                    Y: new double [] {2.0, 3.5, 4.0, 3.0, 4.5, 5.0, 5.5, 6.5, 7.5, 8.0, 8.5, 10.0}
+                                ),
+                                Chart.LineCarpet<int, int, string>(
+                                    a: new int [] {4,5,5,6},
+                                    b: new int [] {1,1,2,3},
+                                    carpetAnchorId: "carpet4",
+                                    Name: "linecarpet"
+                                )
+                            }
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Combine(


### PR DESCRIPTION
This PR adds C# bindings for the rest of the ternary and carpet charts:

- [x] ChartTernary  
	- [x] ScatterTernary
	- [x] PointTernary
	- [x] LineTernary
	- [x] BubbleTernary
 - [x] ChartCarpet 
	- [x] Carpet
	- [x] ScatterCarpet
	- [x] PointCarpet
	- [x] LineCarpet
	- [x] SplineCarpet
	- [x] BubbleCarpet
	- [x] ContourCarpet

The compatibility matrix now looks like this:

![image](https://user-images.githubusercontent.com/21338071/185962455-9d3accd3-555b-42b8-a8bc-8d5f30082c20.png)
