### PR TITLE
[C#] Add C# bindings for Domain and Smith charts

### DIFF
--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -625,6 +625,38 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a table.
+        ///
+        /// The data are arranged in a grid of rows and columns. Most styling can be specified for columns, rows or individual cells. Table is using a row-major order per default, ie. the grid is represented as a vector of row vectors.
+        /// </summary>
+        /// <param name="header">Sets the header of the table</param>
+        /// <param name="cells">Sets the cells of the table</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover.</param>
+        /// <param name="ColumnOrder">Specifies the rendered order of the data columns; for example, a value `2` at position `0` means that column index `0` in the data will be rendered as the third column, as columns have an index base of zero.</param>
+        /// <param name="ColumnWidth">The width of columns expressed as a ratio. Columns fill the available width in proportion of their specified column widths.</param>
+        /// <param name="MultiColumnWidth">The width of columns expressed as a ratio. Columns fill the available width in proportion of their specified column widths.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Table(
+            TableCells header, 
+            TableCells cells, 
+            Optional<string> Name = default, 
+            Optional<IEnumerable<int>> ColumnOrder = default, 
+            Optional<double> ColumnWidth = default, 
+            Optional<IEnumerable<double>> MultiColumnWidth = default, 
+            Optional<bool> UseDefaults = default
+        )
+            =>
+                Plotly.NET.ChartDomain.Chart.Table(
+                   header: header,
+                   cells: cells,
+                   Name: Name.ToOption(),
+                   ColumnOrder: ColumnOrder.ToOption(),
+                   ColumnWidth: ColumnWidth.ToOption(),
+                   MultiColumnWidth: MultiColumnWidth.ToOption(),
+                   UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates an Indicator chart.
         ///
         /// An indicator is used to visualize a single `value` along with some contextual information such as `steps` or a `threshold`, using a combination of three visual elements: a number, a delta, and/or a gauge.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -581,6 +581,50 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a sankey diagram.
+        ///
+        /// A Sankey diagram is a flow diagram, in which the width of arrows is proportional to the flow quantity.
+        ///
+        /// Sankey diagrams visualize the contributions to a flow by defining source to represent the source node, target for the target node, value to set the flow volume, and label that shows the node name.
+        /// </summary>
+        /// <param name="nodes">Sets the nodes of the Sankey plot.</param>
+        /// <param name="links">Sets the links between nodes of the Sankey plot.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover.</param>
+        /// <param name="Ids">Assigns id labels to each datum.</param>
+        /// <param name="Orientation">Sets the orientation of the Sankey diagram.</param>
+        /// <param name="TextFont">Sets the text font of this trace.</param>
+        /// <param name="Arrangement">If value is `snap` (the default), the node arrangement is assisted by automatic snapping of elements to preserve space between nodes specified via `nodepad`. If value is `perpendicular`, the nodes can only move along a line perpendicular to the flow. If value is `freeform`, the nodes can freely move on the plane. If value is `fixed`, the nodes are stationary.</param>
+        /// <param name="ValueFormat">Sets the value formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.</param>
+        /// <param name="ValueSuffix">Adds a unit to follow the value in the hover tooltip. Add a space if a separation is necessary from the value.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Sankey<IdsType>(
+            SankeyNodes nodes,
+            SankeyLinks links,
+            Optional<string> Name = default,
+            Optional<IEnumerable<IdsType>> Ids = default,
+            Optional<StyleParam.Orientation> Orientation = default,
+            Optional<Font> TextFont = default,
+            Optional<StyleParam.CategoryArrangement> Arrangement = default,
+            Optional<string> ValueFormat = default,
+            Optional<string> ValueSuffix = default,
+            Optional<bool> UseDefaults = default
+        )
+            where IdsType : IConvertible
+            =>
+                Plotly.NET.ChartDomain.Chart.Sankey<IdsType>(
+                    nodes: nodes,
+                    links: links,
+                    Name: Name.ToOption(),
+                    Ids: Ids.ToOption(),
+                    Orientation: Orientation.ToOption(),
+                    TextFont: TextFont.ToOption(),
+                    Arrangement: Arrangement.ToOption(),
+                    ValueFormat: ValueFormat.ToOption(),
+                    ValueSuffix: ValueSuffix.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates an Indicator chart.
         ///
         /// An indicator is used to visualize a single `value` along with some contextual information such as `steps` or a `threshold`, using a combination of three visual elements: a number, a delta, and/or a gauge.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -467,6 +467,59 @@ namespace Plotly.NET.CSharp
                     UseDefaults: UseDefaults.ToOption()
                 );
 
+        /// <summary>
+        /// Creates a parallel coordinates plot.
+        ///
+        /// Parallel coordinates are a common way of visualizing and analyzing high-dimensional datasets.
+        ///
+        /// To show a set of points in an n-dimensional space, a backdrop is drawn consisting of n parallel lines, typically vertical and equally spaced. A point in n-dimensional space is represented as a polyline with vertices on the parallel axes; the position of the vertex on the i-th axis corresponds to the i-th coordinate of the point.
+        ///
+        /// This visualization is closely related to time series visualization, except that it is applied to data where the axes do not correspond to points in time, and therefore do not have a natural order. Therefore, different axis arrangements may be of interest.
+        /// </summary>
+        /// <param name="dimensions">the dimensions of the plot, containing both dimension backdrop information and the associated data</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="LineColor">Sets the color of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="LineColorScale">Sets the colorscale of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="ShowLineColorScale">Wether or not to show the colorbar of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="ReverseLineColorScale">Wether or not to reverse the colorscale of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="Line">Sets the lines that are connecting the datums on the dimensions (use this for more finegrained control than the other line-associated arguments).</param>
+        /// <param name="LabelAngle">Sets the angle of the labels with respect to the horizontal. For example, a `tickangle` of -90 draws the labels vertically. Tilted labels with "labelangle" may be positioned better inside margins when `labelposition` is set to "bottom".</param>
+        /// <param name="LabelFont">Sets the label font of this trace.</param>
+        /// <param name="LabelSide">Specifies the location of the `label`. "top" positions labels above, next to the title "bottom" positions labels below the graph Tilted labels with "labelangle" may be positioned better inside margins when `labelposition` is set to "bottom".</param>
+        /// <param name="RangeFont">Sets the range font of this trace.</param>
+        /// <param name="TickFont">Sets the tick font of this trace.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart ParallelCoord(
+            IEnumerable<Dimension> dimensions,
+            Optional<string> Name = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<bool> ShowLineColorScale = default,
+            Optional<bool> ReverseLineColorScale = default,
+            Optional<Line> Line = default,
+            Optional<int> LabelAngle = default,
+            Optional<Font> LabelFont = default,
+            Optional<StyleParam.Side> LabelSide = default,
+            Optional<Font> RangeFont = default,
+            Optional<Font> TickFont = default,
+            Optional<bool> UseDefaults = default
+        )
+            =>
+                Plotly.NET.ChartDomain.Chart.ParallelCoord(
+                    dimensions: dimensions,
+                    Name: Name.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    ShowLineColorScale: ShowLineColorScale.ToOption(),
+                    ReverseLineColorScale: ReverseLineColorScale.ToOption(),
+                    Line: Line.ToOption(),
+                    LabelAngle: LabelAngle.ToOption(),
+                    LabelFont: LabelFont.ToOption(),
+                    LabelSide: LabelSide.ToOption(),
+                    RangeFont: RangeFont.ToOption(),
+                    TickFont: TickFont.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
 
         /// <summary>
         /// Creates an Indicator chart.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -94,6 +94,93 @@ namespace Plotly.NET.CSharp
                     Sort: Sort.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+
+        /// <summary>
+        /// Creates a doughnut chart.
+        ///
+        /// A doughnut chart is a variation of the pie chart that has a fraction cut fron the center of the slices.
+        /// </summary>
+        /// <param name="values">Sets the values of the sectors</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="Hole">Sets the fraction of the radius to cut out of the pie. Use this to make a donut chart.</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Labels">Sets the sector labels. If `labels` entries are duplicated, the associated `values` are summed.</param>
+        /// <param name="Pull">Sets the fraction of larger radius to pull the sectors out from the center. This can be a constant to pull all slices apart from each other equally or an array to highlight one or more slices.</param>
+        /// <param name="MultiPull">Sets the fraction of larger radius to pull the sectors out from the center. This can be a constant to pull all slices apart from each other equally or an array to highlight one or more slices.</param>
+        /// <param name="Text">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="MultiText">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="TextPosition">Sets the positions of the `text` elements with respects to the (x,y) coordinates.</param>
+        /// <param name="MultiTextPosition">Sets the positions of the `text` elements with respects to the (x,y) coordinates.</param>
+        /// <param name="SectionColors">Sets the colors associated with each section.</param>
+        /// <param name="SectionOutlineColor">Sets the color of the section outline.</param>
+        /// <param name="SectionOutlineWidth">Sets the width of the section outline.</param>
+        /// <param name="SectionOutlineMultiWidth">Sets the width of each individual section outline.</param>
+        /// <param name="SectionOutline">Sets the section outline (use this for more finegrained control than the other section outline-associated arguments).</param>
+        /// <param name="Marker">Sets the marker of this trace.</param>
+        /// <param name="TextInfo">Determines which trace information appear on the graph.</param>
+        /// <param name="Direction">Specifies the direction at which succeeding sectors follow one another.</param>
+        /// <param name="Rotation">Instead of the first slice starting at 12 o'clock, rotate to some other angle.</param>
+        /// <param name="Sort">Determines whether or not the sectors are reordered from largest to smallest.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Doughnut<ValuesType, LabelsType, TextType>(
+            IEnumerable<ValuesType> values,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<IEnumerable<LabelsType>> Labels = default,
+            Optional<double> Pull = default,
+            Optional<IEnumerable<double>> MultiPull = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<IEnumerable<Color>> SectionColors = default,
+            Optional<Color> SectionOutlineColor = default,
+            Optional<double> SectionOutlineWidth = default,
+            Optional<IEnumerable<double>> SectionOutlineMultiWidth = default,
+            Optional<Line> SectionOutline = default,
+            Optional<Marker> Marker = default,
+            Optional<StyleParam.TextInfo> TextInfo = default,
+            Optional<StyleParam.Direction> Direction = default,
+            Optional<double> Hole = default,
+            Optional<double> Rotation = default,
+            Optional<bool> Sort = default,
+            Optional<bool> UseDefaults = default
+        )
+            where ValuesType : IConvertible
+            where LabelsType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartDomain.Chart.Doughnut<ValuesType, LabelsType, TextType>(
+                    values: values,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Labels: Labels.ToOption(),
+                    Pull: Pull.ToOption(),
+                    MultiPull: MultiPull.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    SectionColors: SectionColors.ToOption(),
+                    SectionOutlineColor: SectionOutlineColor.ToOption(),
+                    SectionOutlineWidth: SectionOutlineWidth.ToOption(),
+                    SectionOutlineMultiWidth: SectionOutlineMultiWidth.ToOption(),
+                    SectionOutline: SectionOutline.ToOption(),
+                    Marker: Marker.ToOption(),
+                    TextInfo: TextInfo.ToOption(),
+                    Direction: Direction.ToOption(),
+                    Hole: Hole.ToOption(),
+                    Rotation: Rotation.ToOption(),
+                    Sort: Sort.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
         /// <summary>
         /// Creates a FunnelArea chart.
         ///

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -522,6 +522,65 @@ namespace Plotly.NET.CSharp
                 );
 
         /// <summary>
+        /// Creates a parallel categories plot.
+        ///
+        /// The parallel categories diagram (also known as parallel sets or alluvial diagram) is a visualization of
+        /// multi-dimensional categorical data sets. Each variable in the data set is represented by a column of rectangles,
+        /// where each rectangle corresponds to a discrete value taken on by that variable.
+        /// The relative heights of the rectangles reflect the relative frequency of occurrence of the corresponding value.
+        /// </summary>
+        /// <param name="dimensions">the dimensions of the plot, containing both dimension backdrop information and the associated data</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="Counts">The number of observations represented by each state. Defaults to 1 so that each state represents one observation</param>
+        /// <param name="LineColor">Sets the color of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="LineShape">Sets the shape of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="LineColorScale">Sets the colorscale of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="ShowLineColorScale">Wether or not to show the colorbar of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="ReverseLineColorScale">Wether or not to reverse the colorscale of the lines that are connecting the datums on the dimensions</param>
+        /// <param name="Line">Sets the lines that are connecting the datums on the dimensions (use this for more finegrained control than the other line-associated arguments).</param>
+        /// <param name="Arrangement">Sets the drag interaction mode for categories and dimensions. If `perpendicular`, the categories can only move along a line perpendicular to the paths. If `freeform`, the categories can freely move on the plane. If `fixed`, the categories and dimensions are stationary.</param>
+        /// <param name="BundleColors">Sort paths so that like colors are bundled together within each category.</param>
+        /// <param name="SortPaths">Sets the path sorting algorithm. If `forward`, sort paths based on dimension categories from left to right. If `backward`, sort paths based on dimensions categories from right to left.</param>
+        /// <param name="LabelFont">Sets the label font of this trace.</param>
+        /// <param name="TickFont">Sets the tick font of this trace.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart ParallelCategories(
+            IEnumerable<Dimension> dimensions, 
+            Optional<string> Name = default, 
+            Optional<int> Counts = default, 
+            Optional<Color> LineColor = default, 
+            Optional<StyleParam.Shape> LineShape = default, 
+            Optional<StyleParam.Colorscale> LineColorScale = default, 
+            Optional<bool> ShowLineColorScale = default, 
+            Optional<bool> ReverseLineColorScale = default, 
+            Optional<Line> Line = default, 
+            Optional<StyleParam.CategoryArrangement> Arrangement = default, 
+            Optional<bool> BundleColors = default, 
+            Optional<StyleParam.SortAlgorithm> SortPaths = default, 
+            Optional<Font> LabelFont = default, 
+            Optional<Font> TickFont = default, 
+            Optional<bool> UseDefaults = default
+        )
+            =>
+                Plotly.NET.ChartDomain.Chart.ParallelCategories(
+                    dimensions: dimensions,
+                    Name: Name.ToOption(),
+                    Counts: Counts.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineShape: LineShape.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    ShowLineColorScale: ShowLineColorScale.ToOption(),
+                    ReverseLineColorScale: ReverseLineColorScale.ToOption(),
+                    Line: Line.ToOption(),
+                    Arrangement: Arrangement.ToOption(),
+                    BundleColors: BundleColors.ToOption(),
+                    SortPaths: SortPaths.ToOption(),
+                    LabelFont: LabelFont.ToOption(),
+                    TickFont: TickFont.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
+        /// <summary>
         /// Creates an Indicator chart.
         ///
         /// An indicator is used to visualize a single `value` along with some contextual information such as `steps` or a `threshold`, using a combination of three visual elements: a number, a delta, and/or a gauge.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -2,6 +2,7 @@
 using Plotly.NET;
 using Plotly.NET.LayoutObjects;
 using Plotly.NET.TraceObjects;
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
@@ -715,5 +716,115 @@ namespace Plotly.NET.CSharp
                     UseDefaults: UseDefaults.ToOption()
                 );
 
+        /// <summary>
+        /// Creates an icicle chart.
+        ///
+        /// Icicle charts visualize hierarchal data from leaves (and/or outer branches) towards root with rectangles.
+        /// The icicle sectors are determined by the entries in "labels" or "ids" and in "parents".
+        /// </summary>
+        /// <param name="labels">Sets the labels of each of the sectors.</param>
+        /// <param name="parents">Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.</param>
+        /// <param name="Values">Sets the values associated with each of the sectors.</param>
+        /// <param name="Ids">Assigns id labels to each datum. These ids for object constancy of data points during animation.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="MultiText">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="TextPosition">Sets the positions of the `text` elements with respects to the (x,y) coordinates.</param>
+        /// <param name="MultiTextPosition">Sets the positions of the `text` elements with respects to the (x,y) coordinates.</param>
+        /// <param name="SectionColors">Sets the colors associated with each section.</param>
+        /// <param name="SectionColorScale">Sets the colorscale for the section values</param>
+        /// <param name="ShowSectionColorScale">Wether or not to show the section colorbar</param>
+        /// <param name="ReverseSectionColorScale">Wether or not to show the section colorscale</param>
+        /// <param name="SectionOutlineColor">Sets the color of the section outline.</param>
+        /// <param name="SectionOutlineWidth">Sets the width of the section outline.</param>
+        /// <param name="SectionOutlineMultiWidth">Sets the width of each individual section outline.</param>
+        /// <param name="SectionOutline">Sets the section outline (use this for more finegrained control than the other section outline-associated arguments).</param>
+        /// <param name="Marker">Sets the marker of this trace.</param>
+        /// <param name="BranchValues">Determines how the items in `values` are summed. When set to "total", items in `values` are taken to be value of all its descendants. When set to "remainder", items in `values` corresponding to the root and the branches sectors are taken to be the extra part not part of the sum of the values at their leaves.</param>
+        /// <param name="Count">Determines default for `values` when it is not provided, by inferring a 1 for each of the "leaves" and/or "branches", otherwise 0.</param>
+        /// <param name="TilingOrientation">Sets the orientation of the tiling.</param>
+        /// <param name="TilingFlip">Sets the flip of the tiling: Determines if the positions obtained from solver are flipped on each axis.</param>
+        /// <param name="Tiling">Sets the styles for the icicle tiling</param>
+        /// <param name="PathBarEdgeShape">Sets the edge shape of the pathbar.</param>
+        /// <param name="PathBar">Sets the pathbar</param>
+        /// <param name="TextInfo">Determines which trace information appear on the graph.</param>
+        /// <param name="Root">Sets the styles fot the root of this trace.</param>
+        /// <param name="Level">Sets the level from which this trace hierarchy is rendered. Set `level` to `''` to start from the root node in the hierarchy. Must be an "id" if `ids` is filled in, otherwise plotly attempts to find a matching item in `labels`.</param>
+        /// <param name="MaxDepth">Sets the number of rendered sectors from any given `level`. Set `maxdepth` to "-1" to render all the levels in the hierarchy.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Icicle<LabelsType, ParentsType, ValuesType, IdsType, TextType>(
+            IEnumerable<LabelsType> labels,
+            IEnumerable<ParentsType> parents,
+            Optional<IEnumerable<ValuesType>> Values = default,
+            Optional<IEnumerable<IdsType>> Ids = default,
+            Optional<string> Name = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<IEnumerable<Color>> SectionColors = default,
+            Optional<StyleParam.Colorscale> SectionColorScale = default,
+            Optional<bool> ShowSectionColorScale = default,
+            Optional<bool> ReverseSectionColorScale = default,
+            Optional<Color> SectionOutlineColor = default,
+            Optional<double> SectionOutlineWidth = default,
+            Optional<IEnumerable<double>> SectionOutlineMultiWidth = default,
+            Optional<Line> SectionOutline = default,
+            Optional<Marker> Marker = default,
+            Optional<StyleParam.TextInfo> TextInfo = default,
+            Optional<StyleParam.BranchValues> BranchValues = default,
+            Optional<StyleParam.IcicleCount> Count = default,
+            Optional<StyleParam.Orientation> TilingOrientation = default,
+            Optional<StyleParam.TilingFlip> TilingFlip = default,
+            Optional<IcicleTiling> Tiling = default,
+            Optional<StyleParam.PathbarEdgeShape> PathBarEdgeShape = default,
+            Optional<Pathbar> PathBar = default,
+            Optional<IcicleRoot> Root = default,
+            Optional<string> Level = default,
+            Optional<int> MaxDepth = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LabelsType : IConvertible
+            where ParentsType : IConvertible
+            where ValuesType : IConvertible
+            where IdsType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartDomain.Chart.Icicle<LabelsType, ParentsType, ValuesType, IdsType, TextType>(
+                    labels: labels,
+                    parents: parents,
+                    Values: Values.ToOption(),
+                    Ids: Ids.ToOption(),
+                    Name: Name.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    SectionColors: SectionColors.ToOption(),
+                    SectionColorScale: SectionColorScale.ToOption(),
+                    ShowSectionColorScale: ShowSectionColorScale.ToOption(),
+                    ReverseSectionColorScale: ReverseSectionColorScale.ToOption(),
+                    SectionOutlineColor: SectionOutlineColor.ToOption(),
+                    SectionOutlineWidth: SectionOutlineWidth.ToOption(),
+                    SectionOutlineMultiWidth: SectionOutlineMultiWidth.ToOption(),
+                    SectionOutline: SectionOutline.ToOption(),
+                    Marker: Marker.ToOption(),
+                    TextInfo: TextInfo.ToOption(),
+                    BranchValues: BranchValues.ToOption(),
+                    Count: Count.ToOption(),
+                    TilingOrientation: TilingOrientation.ToOption(),
+                    TilingFlip: TilingFlip.ToOption(),
+                    Tiling: Tiling.ToOption(),
+                    PathBarEdgeShape: PathBarEdgeShape.ToOption(),
+                    PathBar: PathBar.ToOption(),
+                    Root: Root.ToOption(),
+                    Level: Level.ToOption(),
+                    MaxDepth: MaxDepth.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
     }
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -1,6 +1,8 @@
-﻿using Plotly.NET;
+﻿using Microsoft.FSharp.Core;
+using Plotly.NET;
 using Plotly.NET.LayoutObjects;
 using Plotly.NET.TraceObjects;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 
@@ -255,6 +257,110 @@ namespace Plotly.NET.CSharp
                     BaseRatio: BaseRatio.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+
+        /// <summary>
+        /// Creates a sunburst chart, which visualizes hierarchical data spanning outward radially from root to leaves.
+        ///
+        /// The hierarchy is defined by labels and parents attributes. The root starts from the center and children are added to the outer rings.
+        /// </summary>
+        /// <param name="labels">Sets the labels of each of the sectors.</param>
+        /// <param name="parents">Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.</param>
+        /// <param name="Values">Sets the values associated with each of the sectors.</param>
+        /// <param name="Ids">Assigns id labels to each datum. These ids for object constancy of data points during animation.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="MultiText">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="SectionColors">Sets the colors associated with each section.</param>
+        /// <param name="SectionColorScale">Sets the colorscale for the section values</param>
+        /// <param name="ShowSectionColorScale">Wether or not to show the section colorbar</param>
+        /// <param name="ReverseSectionColorScale">Wether or not to show the section colorscale</param>
+        /// <param name="SectionOutlineColor">Sets the color of the section outline.</param>
+        /// <param name="SectionOutlineWidth">Sets the width of the section outline.</param>
+        /// <param name="SectionOutlineMultiWidth">Sets the width of each individual section outline.</param>
+        /// <param name="SectionOutline">Sets the section outline (use this for more finegrained control than the other section outline-associated arguments).</param>
+        /// <param name="Marker">Sets the marker of this trace.</param>
+        /// <param name="TextInfo">Determines which trace information appear on the graph.</param>
+        /// <param name="BranchValues">Determines how the items in `values` are summed. When set to "total", items in `values` are taken to be value of all its descendants. When set to "remainder", items in `values` corresponding to the root and the branches sectors are taken to be the extra part not part of the sum of the values at their leaves.</param>
+        /// <param name="Count">Determines default for `values` when it is not provided, by inferring a 1 for each of the "leaves" and/or "branches", otherwise 0.</param>
+        /// <param name="Root">Sets the styles fot the root of this trace.</param>
+        /// <param name="Leaf">Sets the styles fot the leaves of this trace.</param>
+        /// <param name="Level">Sets the level from which this trace hierarchy is rendered. Set `level` to `''` to start from the root node in the hierarchy. Must be an "id" if `ids` is filled in, otherwise plotly attempts to find a matching item in `labels`.</param>
+        /// <param name="MaxDepth">Sets the number of rendered sectors from any given `level`. Set `maxdepth` to "-1" to render all the levels in the hierarchy.</param>
+        /// <param name="Rotation">Rotates the whole diagram counterclockwise by some angle. By default the first slice starts at 3 o'clock.</param>
+        /// <param name="Sort">Determines whether or not the sectors are reordered from largest to smallest.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Sunburst<LabelsType, ParentsType, ValuesType, IdsType, TextType>(
+            IEnumerable<LabelsType> labels,
+            IEnumerable<ParentsType> parents,
+            Optional<IEnumerable<ValuesType>> Values = default,
+            Optional<IEnumerable<IdsType>> Ids = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<IEnumerable<Color>> SectionColors = default,
+            Optional<StyleParam.Colorscale> SectionColorScale = default,
+            Optional<bool> ShowSectionColorScale = default,
+            Optional<bool> ReverseSectionColorScale = default,
+            Optional<Color> SectionOutlineColor = default,
+            Optional<double> SectionOutlineWidth = default,
+            Optional<IEnumerable<double>> SectionOutlineMultiWidth = default,
+            Optional<Line> SectionOutline = default,
+            Optional<Marker> Marker = default,
+            Optional<StyleParam.TextInfo> TextInfo = default,
+            Optional<StyleParam.BranchValues> BranchValues = default,
+            Optional<string> Count = default,
+            Optional<SunburstRoot> Root = default,
+            Optional<SunburstLeaf> Leaf = default,
+            Optional<string> Level = default,
+            Optional<int> MaxDepth = default,
+            Optional<int> Rotation = default,
+            Optional<bool> Sort = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LabelsType : IConvertible
+            where ParentsType : IConvertible
+            where ValuesType : IConvertible
+            where IdsType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartDomain.Chart.Sunburst<LabelsType, ParentsType, ValuesType, IdsType, TextType>(
+                    labels: labels,
+                    parents: parents,
+                    Values: Values.ToOption(),
+                    Ids: Ids.ToOption(),
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    SectionColors: SectionColors.ToOption(),
+                    SectionColorScale: SectionColorScale.ToOption(),
+                    ShowSectionColorScale: ShowSectionColorScale.ToOption(),
+                    ReverseSectionColorScale: ReverseSectionColorScale.ToOption(),
+                    SectionOutlineColor: SectionOutlineColor.ToOption(),
+                    SectionOutlineWidth: SectionOutlineWidth.ToOption(),
+                    SectionOutlineMultiWidth: SectionOutlineMultiWidth.ToOption(),
+                    SectionOutline: SectionOutline.ToOption(),
+                    Marker: Marker.ToOption(),
+                    TextInfo: TextInfo.ToOption(),
+                    BranchValues: BranchValues.ToOption(),
+                    Count: Count.ToOption(),
+                    Root: Root.ToOption(),
+                    Leaf: Leaf.ToOption(),
+                    Level: Level.ToOption(),
+                    MaxDepth: MaxDepth.ToOption(),
+                    Rotation: Rotation.ToOption(),
+                    Sort: Sort.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
 
         /// <summary>
         /// Creates an Indicator chart.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartDomain.cs
@@ -361,6 +361,112 @@ namespace Plotly.NET.CSharp
                     UseDefaults: UseDefaults.ToOption()
                 );
 
+        /// <summary>
+        /// Creates a treemap chart.
+        /// Treemap charts visualize hierarchical data using nested rectangles.
+        ///
+        /// Same as Sunburst the hierarchy is defined by labels and parents attributes.
+        /// Click on one sector to zoom in/out, which also displays a pathbar in the upper-left corner of your treemap. To zoom out you can use the path bar as well.
+        /// </summary>
+        /// <param name="labels">Sets the labels of each of the sectors.</param>
+        /// <param name="parents">Sets the parent sectors for each of the sectors. Empty string items '' are understood to reference the root node in the hierarchy. If `ids` is filled, `parents` items are understood to be "ids" themselves. When `ids` is not set, plotly attempts to find matching items in `labels`, but beware they must be unique.</param>
+        /// <param name="Values">Sets the values associated with each of the sectors.</param>
+        /// <param name="Ids">Assigns id labels to each datum. These ids for object constancy of data points during animation.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="MultiText">Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a "text" flag and "hovertext" is not set, these elements will be seen in the hover labels.</param>
+        /// <param name="TextPosition">Sets the positions of the `text` elements with respects to the (x,y) coordinates.</param>
+        /// <param name="MultiTextPosition">Sets the positions of the `text` elements with respects to the (x,y) coordinates.</param>
+        /// <param name="SectionColors">Sets the colors associated with each section.</param>
+        /// <param name="SectionColorScale">Sets the colorscale for the section values</param>
+        /// <param name="ShowSectionColorScale">Wether or not to show the section colorbar</param>
+        /// <param name="ReverseSectionColorScale">Wether or not to show the section colorscale</param>
+        /// <param name="SectionOutlineColor">Sets the color of the section outline.</param>
+        /// <param name="SectionOutlineWidth">Sets the width of the section outline.</param>
+        /// <param name="SectionOutlineMultiWidth">Sets the width of each individual section outline.</param>
+        /// <param name="SectionOutline">Sets the section outline (use this for more finegrained control than the other section outline-associated arguments).</param>
+        /// <param name="Marker">Sets the marker of this trace.</param>
+        /// <param name="TextInfo">Determines which trace information appear on the graph.</param>
+        /// <param name="BranchValues">Determines how the items in `values` are summed. When set to "total", items in `values` are taken to be value of all its descendants. When set to "remainder", items in `values` corresponding to the root and the branches sectors are taken to be the extra part not part of the sum of the values at their leaves.</param>
+        /// <param name="Count">Determines default for `values` when it is not provided, by inferring a 1 for each of the "leaves" and/or "branches", otherwise 0.</param>
+        /// <param name="Tiling">Sets the tiling for this trace.</param>
+        /// <param name="PathBar">Sets the path bar for this trace.</param>
+        /// <param name="Root">Sets the styles fot the root of this trace.</param>
+        /// <param name="Level">Sets the level from which this trace hierarchy is rendered. Set `level` to `''` to start from the root node in the hierarchy. Must be an "id" if `ids` is filled in, otherwise plotly attempts to find a matching item in `labels`.</param>
+        /// <param name="MaxDepth">Sets the number of rendered sectors from any given `level`. Set `maxdepth` to "-1" to render all the levels in the hierarchy.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart Treemap<LabelsType, ParentsType, ValuesType, IdsType, TextType>(
+            IEnumerable<LabelsType> labels,
+            IEnumerable<ParentsType> parents,
+            Optional<IEnumerable<ValuesType>> Values = default,
+            Optional<IEnumerable<IdsType>> Ids = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<IEnumerable<Color>> SectionColors = default,
+            Optional<StyleParam.Colorscale> SectionColorScale = default,
+            Optional<bool> ShowSectionColorScale = default,
+            Optional<bool> ReverseSectionColorScale = default,
+            Optional<Color> SectionOutlineColor = default,
+            Optional<double> SectionOutlineWidth = default,
+            Optional<IEnumerable<double>> SectionOutlineMultiWidth = default,
+            Optional<Line> SectionOutline = default,
+            Optional<Marker> Marker = default,
+            Optional<StyleParam.TextInfo> TextInfo = default,
+            Optional<StyleParam.BranchValues> BranchValues = default,
+            Optional<string> Count = default,
+            Optional<TreemapTiling> Tiling = default,
+            Optional<Pathbar> PathBar = default,
+            Optional<TreemapRoot> Root = default,
+            Optional<string> Level = default,
+            Optional<int> MaxDepth = default,
+            Optional<bool> UseDefaults = default
+        )
+            where LabelsType : IConvertible
+            where ParentsType : IConvertible
+            where ValuesType : IConvertible
+            where IdsType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartDomain.Chart.Treemap<LabelsType, ParentsType, ValuesType, IdsType, TextType>(
+                    labels: labels,
+                    parents: parents,
+                    Values: Values.ToOption(),
+                    Ids: Ids.ToOption(),
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    SectionColors: SectionColors.ToOption(),
+                    SectionColorScale: SectionColorScale.ToOption(),
+                    ShowSectionColorScale: ShowSectionColorScale.ToOption(),
+                    ReverseSectionColorScale: ReverseSectionColorScale.ToOption(),
+                    SectionOutlineColor: SectionOutlineColor.ToOption(),
+                    SectionOutlineWidth: SectionOutlineWidth.ToOption(),
+                    SectionOutlineMultiWidth: SectionOutlineMultiWidth.ToOption(),
+                    SectionOutline: SectionOutline.ToOption(),
+                    Marker: Marker.ToOption(),
+                    TextInfo: TextInfo.ToOption(),
+                    BranchValues: BranchValues.ToOption(),
+                    Count: Count.ToOption(),
+                    Tiling: Tiling.ToOption(),
+                    PathBar: PathBar.ToOption(),
+                    Root: Root.ToOption(),
+                    Level: Level.ToOption(),
+                    MaxDepth: MaxDepth.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
+
 
         /// <summary>
         /// Creates an Indicator chart.

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartSmith.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartSmith.cs
@@ -251,5 +251,87 @@ namespace Plotly.NET.CSharp
                     FillColor: FillColor.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+        /// <summary>
+        /// Creates a Bubble plot on a smith coordinate system. A bubble chart is a variation of the Point chart, where the data points get an additional scale by being rendered as bubbles of different sizes.
+        ///
+        /// In general, BubbleSmith charts plot complex numbers on a transformed two-dimensional Cartesian complex plane as points of varying sizes. Complex numbers with positive real parts map inside the circle. Those with negative real parts map outside the circle.
+        /// </summary>
+        /// <param name="real">Sets the real component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.</param>
+        /// <param name="imag">Sets the imaginary component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.</param>
+        /// <param name="sizes">Sets the size of the points</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart BubbleSmith<RealType, ImagType, TextType>(
+            IEnumerable<RealType> real,
+            IEnumerable<ImagType> imag,
+            IEnumerable<int> sizes,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<bool> UseDefaults = default
+        )
+            where RealType : IConvertible
+            where ImagType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartSmith.Chart.BubbleSmith<RealType, ImagType, TextType>(
+                    real: real,
+                    imag: imag,
+                    sizes: sizes,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    LineWidth: LineWidth.ToOption(),
+                    LineDash: LineDash.ToOption(),
+                    Line: Line.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
     }
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartSmith.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartSmith.cs
@@ -162,5 +162,94 @@ namespace Plotly.NET.CSharp
                     Marker: Marker.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+
+        /// <summary>
+        /// Creates a Line plot on a smith coordinate system.
+        ///
+        /// In general, LineSmith charts plot complex numbers on a transformed two-dimensional Cartesian complex plane as datums connected by a line. Complex numbers with positive real parts map inside the circle. Those with negative real parts map outside the circle.
+        /// </summary>
+        /// <param name="real">Sets the real component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.</param>
+        /// <param name="imag">Sets the imaginary component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.</param>
+        /// <param name="ShowMarkers">Wether or not to show markers for each datum.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="LineColor">Sets the color of the line</param>
+        /// <param name="LineColorScale">Sets the colorscale of the line</param>
+        /// <param name="LineWidth">Sets the width of the line</param>
+        /// <param name="LineDash">sets the drawing style of the line</param>
+        /// <param name="Line">Sets the line (use this for more finegrained control than the other line-associated arguments)</param>
+        /// <param name="Fill">Sets the area to fill with a solid color. Defaults to "none" unless this trace is stacked, then it gets "tonexty" ("tonextx") if `orientation` is "v" ("h") Use with `FillColor` if not "none". "tozerox" and "tozeroy" fill to x=0 and y=0 respectively. "tonextx" and "tonexty" fill between the endpoints of this trace and the endpoints of the trace before it, connecting those endpoints with straight lines (to make a stacked area graph); if there is no trace before it, they behave like "tozerox" and "tozeroy". "toself" connects the endpoints of the trace (or each segment of the trace if it has gaps) into a closed shape. "tonext" fills the space between two traces if one completely encloses the other (eg consecutive contour lines), and behaves like "toself" if there is no trace before it. "tonext" should not be used if one trace does not enclose the other. Traces in a `stackgroup` will only fill to (or be filled to) other traces in the same group. With multiple `stackgroup`s or some traces stacked and some not, if fill-linked traces are not already consecutive, the later ones will be pushed down in the drawing order.</param>
+        /// <param name="FillColor">ets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart LineSmith<RealType, ImagType, TextType>(
+            IEnumerable<RealType> real,
+            IEnumerable<ImagType> imag,
+            Optional<bool> ShowMarkers = default,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<Color> LineColor = default,
+            Optional<StyleParam.Colorscale> LineColorScale = default,
+            Optional<double> LineWidth = default,
+            Optional<StyleParam.DrawingStyle> LineDash = default,
+            Optional<Line> Line = default,
+            Optional<StyleParam.Fill> Fill = default,
+            Optional<Color> FillColor = default,
+            Optional<bool> UseDefaults = default
+        )
+            where RealType : IConvertible
+            where ImagType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartSmith.Chart.LineSmith<RealType, ImagType, TextType>(
+                    real: real,
+                    imag: imag,
+                    ShowMarkers: ShowMarkers.ToOption(),
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    LineColor: LineColor.ToOption(),
+                    LineColorScale: LineColorScale.ToOption(),
+                    LineWidth: LineWidth.ToOption(),
+                    LineDash: LineDash.ToOption(),
+                    Line: Line.ToOption(),
+                    Fill: Fill.ToOption(),
+                    FillColor: FillColor.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
     }
 }

--- a/src/Plotly.NET.CSharp/ChartAPI/ChartSmith.cs
+++ b/src/Plotly.NET.CSharp/ChartAPI/ChartSmith.cs
@@ -97,5 +97,70 @@ namespace Plotly.NET.CSharp
                     FillColor: FillColor.ToOption(),
                     UseDefaults: UseDefaults.ToOption()
                 );
+
+        /// <summary>
+        /// Creates a Point plot on a smith coordinate system.
+        ///
+        /// In general, ScatterPoint charts plot complex numbers on a transformed two-dimensional Cartesian complex plane as points. Complex numbers with positive real parts map inside the circle. Those with negative real parts map outside the circle.
+        /// </summary>
+        /// <param name="real">Sets the real component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.</param>
+        /// <param name="imag">Sets the imaginary component of the data, in units of normalized impedance such that real=1, imag=0 is the center of the chart.</param>
+        /// <param name="Name">Sets the trace name. The trace name appear as the legend item and on hover</param>
+        /// <param name="ShowLegend">Determines whether or not an item corresponding to this trace is shown in the legend.</param>
+        /// <param name="Opacity">Sets the opactity of the trace</param>
+        /// <param name="MultiOpacity">Sets the opactity of individual datum markers</param>
+        /// <param name="Text">Sets a text associated with each datum</param>
+        /// <param name="MultiText">Sets individual text for each datum</param>
+        /// <param name="TextPosition">Sets the position of text associated with each datum</param>
+        /// <param name="MultiTextPosition">Sets the position of text associated with individual datum</param>
+        /// <param name="MarkerColor">Sets the color of the marker</param>
+        /// <param name="MarkerColorScale">Sets the colorscale of the marker</param>
+        /// <param name="MarkerOutline">Sets the outline of the marker</param>
+        /// <param name="MarkerSymbol">Sets the marker symbol for each datum</param>
+        /// <param name="MultiMarkerSymbol">Sets the marker symbol for each individual datum</param>
+        /// <param name="Marker">Sets the marker (use this for more finegrained control than the other marker-associated arguments)</param>
+        /// <param name="UseDefaults">If set to false, ignore the global default settings set in `Defaults`</param>
+        public static GenericChart.GenericChart PointSmith<RealType, ImagType, TextType>(
+            IEnumerable<RealType> real,
+            IEnumerable<ImagType> imag,
+            Optional<string> Name = default,
+            Optional<bool> ShowLegend = default,
+            Optional<double> Opacity = default,
+            Optional<IEnumerable<double>> MultiOpacity = default,
+            Optional<TextType> Text = default,
+            Optional<IEnumerable<TextType>> MultiText = default,
+            Optional<StyleParam.TextPosition> TextPosition = default,
+            Optional<IEnumerable<StyleParam.TextPosition>> MultiTextPosition = default,
+            Optional<Color> MarkerColor = default,
+            Optional<StyleParam.Colorscale> MarkerColorScale = default,
+            Optional<Line> MarkerOutline = default,
+            Optional<StyleParam.MarkerSymbol> MarkerSymbol = default,
+            Optional<IEnumerable<StyleParam.MarkerSymbol>> MultiMarkerSymbol = default,
+            Optional<Marker> Marker = default,
+            Optional<bool> UseDefaults = default
+        )
+            where RealType : IConvertible
+            where ImagType : IConvertible
+            where TextType : IConvertible
+            =>
+                Plotly.NET.ChartSmith.Chart.PointSmith<RealType, ImagType, TextType>(
+                    real: real,
+                    imag: imag,
+                    Name: Name.ToOption(),
+                    ShowLegend: ShowLegend.ToOption(),
+                    Opacity: Opacity.ToOption(),
+                    MultiOpacity: MultiOpacity.ToOption(),
+                    Text: Text.ToOption(),
+                    MultiText: MultiText.ToOption(),
+                    TextPosition: TextPosition.ToOption(),
+                    MultiTextPosition: MultiTextPosition.ToOption(),
+                    MarkerColor: MarkerColor.ToOption(),
+                    MarkerColorScale: MarkerColorScale.ToOption(),
+                    MarkerOutline: MarkerOutline.ToOption(),
+                    MarkerSymbol: MarkerSymbol.ToOption(),
+                    MultiMarkerSymbol: MultiMarkerSymbol.ToOption(),
+                    Marker: Marker.ToOption(),
+                    UseDefaults: UseDefaults.ToOption()
+                );
     }
 }

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -746,11 +746,17 @@ namespace TestConsoleApp
                         Chart.ParallelCoord(
                             dimensions: new Plotly.NET.TraceObjects.Dimension [] {
                                 Plotly.NET.TraceObjects.Dimension.initParallel<string, string, int, int>(Label: "A", Values: new int [] {1, 4, 3}),
-                                Plotly.NET.TraceObjects.Dimension.initParallel<string, string, int, int>(Label: "A", Values: new int [] {3, 1, 2})
+                                Plotly.NET.TraceObjects.Dimension.initParallel<string, string, int, int>(Label: "B", Values: new int [] {3, 1, 2})
                             },
                             Name: "parcoords"
                         ),
-                        Chart.Invisible(),
+                        Chart.ParallelCategories(
+                            dimensions: new Plotly.NET.TraceObjects.Dimension [] {
+                                Plotly.NET.TraceObjects.Dimension.initParallel<string, string, int, int>(Label: "A", Values: new int [] {1, 1, 2}),
+                                Plotly.NET.TraceObjects.Dimension.initParallel<string, string, int, int>(Label: "B", Values: new int [] {3, 3, 3})
+                            },
+                            Name: "parcats"
+                        ),
                         Chart.Invisible(),
 
                         //smith traces

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -737,7 +737,12 @@ namespace TestConsoleApp
                             parents: new string [] {"", "", "B"},
                             Name: "sunburst"
                         ),
-                        Chart.Invisible(),
+                        Chart.Treemap<string, string, int, string, string>(
+                            Values: new int [] {19, 26, 55},
+                            labels: new string [] {"A", "B", "C"},
+                            parents: new string [] {"", "", "B"},
+                            Name: "sunburst"
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -775,18 +775,35 @@ namespace TestConsoleApp
                             imag: new double [] {1,2,3,4},
                             mode: Mode.Markers,
                             Name: "scattersmith"
+                        ).WithTraceInfo(
+                            LegendGroup: "scattersmith-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattersmith derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.PointSmith<double,double,string>(
                             real: new double [] {1,2,3,4},
                             imag: new double [] {1,2,3,4},
                             Name: "pointsmith"
+                        ).WithTraceInfo(
+                            LegendGroup: "scattersmith-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattersmith derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
                         Chart.LineSmith<double,double,string>(
                             real: new double [] {1,2,3,4},
                             imag: new double [] {1,2,3,4},
                             Name: "linesmith"
+                        ).WithTraceInfo(
+                            LegendGroup: "scattersmith-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattersmith derived traces", Font: Plotly.NET.Font.init(Size: 20))
                         ),
-                        Chart.Invisible(),
+                        Chart.BubbleSmith<double,double,string>(
+                            sizes: new int [] {10, 20, 30, 40},
+                            real: new double [] {1,2,3,4},
+                            imag: new double [] {1,2,3,4},
+                            Name: "bubblesmith"
+                        ).WithTraceInfo(
+                            LegendGroup: "scattersmith-derived",
+                            LegendGroupTitle: Plotly.NET.Title.init("scattersmith derived traces", Font: Plotly.NET.Font.init(Size: 20))
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible()

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -722,10 +722,15 @@ namespace TestConsoleApp
 
                         //domain traces
                         Chart.Pie<double,string,string>(
-                            values: new double [] {1,2,3,4},
-                            Labels: new string [] {"soos", "saas", "fiif", "leel"}
+                            values: new double [] {69, 420},
+                            Labels: new string [] {"A", "B"},
+                            Name: "pie"
                         ),
-                        Chart.Invisible(),
+                        Chart.Doughnut<double,string,string>(
+                            values: new double [] {69, 420},
+                            Labels: new string [] {"A", "B"},
+                            Name: "doughnut"
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -77,12 +77,12 @@ namespace TestConsoleApp
                                     x: new int [] { 3, 4, 5},
                                     y: new int [] { 3, 1, 4},
                                     Name: "splinearea"
-                                ),                                
+                                ),
                                 Chart.StackedArea<int,int,string>(
                                     x: new int [] { 6, 7},
                                     y: new int [] { 3, 1},
                                     Name: "stacked area 1"
-                                ),                                
+                                ),
                                 Chart.StackedArea<int,int,string>(
                                     x: new int [] { 6, 7},
                                     y: new int [] { 3, 2},
@@ -152,7 +152,7 @@ namespace TestConsoleApp
                         ).WithTraceInfo(
                             LegendGroup: "other-simple-2D",
                             LegendGroupTitle: Plotly.NET.Title.init("other simple 2D traces", Font: Plotly.NET.Font.init(Size: 20))
-                        ),                        
+                        ),
                         Chart.Image<string>(
                             Source: @"data:image/gif;base64,R0lGODdhEAAQAMwAAPj7+FmhUYjNfGuxYYDJdYTIeanOpT+DOTuANXi/bGOrWj6CONzv2sPjv2CmV1unU4zPgI/Sg6DJnJ3ImTh8Mtbs00aNP1CZSGy0YqLEn47RgXW8amasW7XWsmmvX2iuXiwAAAAAEAAQAAAFVyAgjmRpnihqGCkpDQPbGkNUOFk6DZqgHCNGg2T4QAQBoIiRSAwBE4VA4FACKgkB5NGReASFZEmxsQ0whPDi9BiACYQAInXhwOUtgCUQoORFCGt/g4QAIQA7"
                         ).WithTraceInfo(
@@ -329,7 +329,7 @@ namespace TestConsoleApp
                                     z: new int [] { 14, 15 },
                                     mode: Mode.Markers,
                                     Name: "scatter3D"
-                                ),                                
+                                ),
                                 Chart.Point3D<int,int,int,string>(
                                     x: new int[] { 3, 4 },
                                     y: new int [] { 13, 14 },
@@ -379,18 +379,18 @@ namespace TestConsoleApp
                         Chart.Cone<int,int,int,int,int,int,string>(
                             x: new int [] { 0, 1, 2, 0 },
                             y: new int [] { 0, 0, 1, 2 },
-                            z: new int [] { 0, 2, 0, 1 },                            
+                            z: new int [] { 0, 2, 0, 1 },
                             u: new int [] { 0, 1, 2, 0 },
                             v: new int [] { 0, 0, 1, 2 },
                             w: new int [] { 0, 2, 0, 1 },
                             ShowScale: false,
                             Name: "cone",
                             ShowLegend: true
-                        ),                        
+                        ),
                         Chart.StreamTube<int,int,int,int,int,int,string>(
                             x: new int [] { 0, 0, 0 },
                             y: new int [] { 0, 1, 2},
-                            z: new int [] { 0, 0, 0},                            
+                            z: new int [] { 0, 0, 0},
                             u: new int [] { 0, 0, 0},
                             v: new int [] { 1, 1, 1},
                             w: new int [] { 0, 0, 0},
@@ -406,7 +406,7 @@ namespace TestConsoleApp
                             ShowScale: false,
                             Name: "volume",
                             ShowLegend: true
-                        ),                        
+                        ),
                         Chart.IsoSurface<double,double,double,double,string>(
                             x: new double [] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
                             y: new double [] { 1, 1, 1, 1.5, 1.5, 1.5, 2, 2, 2, 1, 1, 1, 1.5, 1.5, 1.5, 2, 2, 2, 1, 1, 1, 1.5, 1.5, 1.5, 2, 2, 2 },
@@ -466,12 +466,12 @@ namespace TestConsoleApp
                                     longitudes: new int [] { 40, 50 },
                                     latitudes: new int [] { 60, 70 },
                                     Name: "pointgeo"
-                                ),                                
+                                ),
                                 Chart.LineGeo<int,int,string>(
                                     longitudes: new int [] { 10,  -100},
                                     latitudes: new int [] { 50, 50 },
                                     Name: "linegeo"
-                                ),                                
+                                ),
                                 Chart.BubbleGeo<int,int,string>(
                                     longitudes: new int [] { 80,  -80},
                                     latitudes: new int [] { 20, -20 },
@@ -731,7 +731,12 @@ namespace TestConsoleApp
                             Labels: new string [] {"A", "B"},
                             Name: "doughnut"
                         ),
-                        Chart.Invisible(),
+                        Chart.Sunburst<string, string, int, string, string>(
+                            Values: new int [] {19, 26, 55},
+                            labels: new string [] {"A", "B", "C"},
+                            parents: new string [] {"", "", "B"},
+                            Name: "sunburst"
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -757,7 +757,16 @@ namespace TestConsoleApp
                             },
                             Name: "parcats"
                         ),
-                        Chart.Invisible(),
+                        Chart.Sankey<string>(
+                            nodes: Plotly.NET.TraceObjects.SankeyNodes.init<string, int [], string, string>(
+                                Label: new string [] {"A", "B", "C", "D"}
+                            ),
+                            links: Plotly.NET.TraceObjects.SankeyLinks.init<string, int>(
+                                Source: new int [] {0, 1, 1 },
+                                Target: new int [] {2, 2, 3 },
+                                Value: new int [] {1, 2, 5}
+                            )
+                        ),
 
                         //smith traces
                         Chart.ScatterSmith<double,double,string>(

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -736,7 +736,7 @@ namespace TestConsoleApp
                             Values: new int [] {19, 26, 55},
                             labels: new string [] {"A", "B", "C"},
                             parents: new string [] {"", "", "B"},
-                            Name: "sunburst"
+                            Name: "treemap"
                         ),
                         Chart.ParallelCoord(
                             dimensions: new Plotly.NET.TraceObjects.Dimension [] {
@@ -762,7 +762,12 @@ namespace TestConsoleApp
                                 Value: new int [] {1, 2, 5}
                             )
                         ),
-                        
+                        Chart.Icicle<string, string, int, string, string>(
+                            Values: new int [] {19, 26, 55},
+                            labels: new string [] {"A", "B", "C"},
+                            parents: new string [] {"", "", "B"},
+                            Name: "icicle"
+                        ),
 
                         //smith traces
                         Chart.ScatterSmith<double,double,string>(

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -781,7 +781,11 @@ namespace TestConsoleApp
                             imag: new double [] {1,2,3,4},
                             Name: "pointsmith"
                         ),
-                        Chart.Invisible(),
+                        Chart.LineSmith<double,double,string>(
+                            real: new double [] {1,2,3,4},
+                            imag: new double [] {1,2,3,4},
+                            Name: "linesmith"
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -726,11 +726,6 @@ namespace TestConsoleApp
                             Labels: new string [] {"A", "B"},
                             Name: "pie"
                         ),
-                        Chart.Doughnut<double,string,string>(
-                            values: new double [] {69, 420},
-                            Labels: new string [] {"A", "B"},
-                            Name: "doughnut"
-                        ),
                         Chart.Sunburst<string, string, int, string, string>(
                             Values: new int [] {19, 26, 55},
                             labels: new string [] {"A", "B", "C"},
@@ -767,6 +762,7 @@ namespace TestConsoleApp
                                 Value: new int [] {1, 2, 5}
                             )
                         ),
+                        
 
                         //smith traces
                         Chart.ScatterSmith<double,double,string>(

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -743,7 +743,13 @@ namespace TestConsoleApp
                             parents: new string [] {"", "", "B"},
                             Name: "sunburst"
                         ),
-                        Chart.Invisible(),
+                        Chart.ParallelCoord(
+                            dimensions: new Plotly.NET.TraceObjects.Dimension [] {
+                                Plotly.NET.TraceObjects.Dimension.initParallel<string, string, int, int>(Label: "A", Values: new int [] {1, 4, 3}),
+                                Plotly.NET.TraceObjects.Dimension.initParallel<string, string, int, int>(Label: "A", Values: new int [] {3, 1, 2})
+                            },
+                            Name: "parcoords"
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
 

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -773,9 +773,14 @@ namespace TestConsoleApp
                         Chart.ScatterSmith<double,double,string>(
                             real: new double [] {1,2,3,4},
                             imag: new double [] {1,2,3,4},
-                            mode: Mode.Markers
+                            mode: Mode.Markers,
+                            Name: "scattersmith"
                         ),
-                        Chart.Invisible(),
+                        Chart.PointSmith<double,double,string>(
+                            real: new double [] {1,2,3,4},
+                            imag: new double [] {1,2,3,4},
+                            Name: "pointsmith"
+                        ),
                         Chart.Invisible(),
                         Chart.Invisible(),
                         Chart.Invisible(),


### PR DESCRIPTION
This PR adds C# bindings for the rest of the missing charts:

- [x] ChartDomain
	- [x] Pie
	- [x] Doughnut
	- [x] FunnelArea
	- [x] Sunburst
	- [x] Treemap
	- [x] ParralelCoord
	- [x] ParralelCategories
	- [x] Sankey
	- [x] Table
	- [x] Indicator
	- [x] Icicle
 - [x] ChartSmith
	- [x] ScatterSmith
	- [x] PointSmith
	- [x] LineSmith
	- [x] BubbleSmith

Here is a matrix of all charts you can do with the C# API:

![image](https://user-images.githubusercontent.com/21338071/186194144-7cfb9869-a06a-4682-bce7-ab06630f204d.png)
