### PR TITLE
Use Giraffe.ViewEngine as html dsl

### DIFF
--- a/src/Plotly.NET/CSharpLayer/GenericChartExtensions.fs
+++ b/src/Plotly.NET/CSharpLayer/GenericChartExtensions.fs
@@ -4,6 +4,7 @@ open Plotly.NET.LayoutObjects
 open Plotly.NET.TraceObjects
 open System
 open System.IO
+open Giraffe.ViewEngine
 
 open DynamicObj
 open GenericChart
@@ -941,19 +942,19 @@ module GenericChartExtensions =
         /// Show chart in browser
         [<CompiledName("WithDescription")>]
         [<Extension>]
-        member this.WithDescription(description: ChartDescription) =
+        member this.WithDescription(description: XmlNode list) =
             this |> Chart.withDescription description
 
         /// Adds the given additional script tags on the chart's DisplayOptions. They will be included in the document's <head>
         [<CompiledName("WithAdditionalHeadTags")>]
         [<Extension>]
-        member this.WithAdditionalHeadTags(additionalHeadTags: seq<string>) =
+        member this.WithAdditionalHeadTags(additionalHeadTags: XmlNode list) =
             this |> Chart.withAdditionalHeadTags additionalHeadTags
 
         /// Sets the given additional script tags on the chart's DisplayOptions. They will be included in the document's <head>
         [<CompiledName("WithHeadTags")>]
         [<Extension>]
-        member this.WithHeadTags(headTags: seq<string>) = this |> Chart.withHeadTags headTags
+        member this.WithHeadTags(headTags: XmlNode list) = this |> Chart.withHeadTags headTags
 
         /// Adds the necessary script tags to render tex strings to the chart's DisplayOptions
         [<CompiledName("WithMathTex")>]
@@ -978,11 +979,6 @@ module GenericChartExtensions =
         [<CompiledName("Show")>]
         [<Extension>]
         member this.Show() = this |> Chart.show
-
-        /// Show chart in browser
-        [<CompiledName("ShowAsImage")>]
-        [<Extension>]
-        member this.ShowAsImage(format: StyleParam.ImageFormat) = this |> Chart.showAsImage format
 
         /// Sets the polar object with the given id on the chart layout
         [<CompiledName("WithPolar")>]

--- a/src/Plotly.NET/Globals.fs
+++ b/src/Plotly.NET/Globals.fs
@@ -1,0 +1,29 @@
+﻿module Globals
+
+open DynamicObj
+open System.Runtime.InteropServices
+open Newtonsoft.Json
+open Giraffe.ViewEngine
+
+/// The plotly js version loaded from cdn in rendered html docs
+let [<Literal>] PLOTLYJS_VERSION = "2.17.1"
+
+/// 
+let internal JSON_CONFIG = 
+    JsonSerializerSettings(
+        ReferenceLoopHandling = ReferenceLoopHandling.Serialize
+    )
+
+/// the mathjax v2 tags to add to html docs for rendering latex
+let internal MATHJAX_V2_TAGS =
+    [
+        script [_type "text/x-mathjax-config;executed=true"] [rawText """MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']], processEscapes: true}});"""]
+        script [_type "text/javascript"; _src """https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML%2CSafe.js&ver=4.1"""] []
+    ]
+
+/// the mathjax v3 tags to add to html docs for rendering latex
+let internal MATHJAX_V3_TAGS =
+    [
+        script [] [rawText """MathJax = {tex: {inlineMath: [['$', '$'], ['\\(', '\\)']]}};"""]
+        script [_src """https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-svg.js"""] []
+    ]

--- a/src/Plotly.NET/Plotly.NET.fsproj
+++ b/src/Plotly.NET/Plotly.NET.fsproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <None Include="RELEASE_NOTES.md" />
     <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="\" />
+    <Compile Include="Globals.fs" />
     <Compile Include="InternalUtils.fs" />
     <Compile Include="CommonAbstractions\ColorKeyword.fs" />
     <Compile Include="CommonAbstractions\Colors.fs" />
@@ -160,6 +161,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="DynamicObj" Version="2.0.0" />
+    <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Layout\ObjectAbstractions\Carpet\" />

--- a/src/Plotly.NET/Templates/Defaults.fs
+++ b/src/Plotly.NET/Templates/Defaults.fs
@@ -25,7 +25,7 @@ module Defaults =
 
     /// The display options used for generating html. Default: DisplayOptions.init ()
     let mutable DefaultDisplayOptions =
-        DisplayOptions.init ()
+        DisplayOptions.Create()
 
     /// The default chart template. Default: ChartTemplates.plotly
     let mutable DefaultTemplate =
@@ -36,5 +36,5 @@ module Defaults =
         DefaultWidth <- 600
         DefaultHeight <- 600
         DefaultConfig <- Config.init (Responsive = true)
-        DefaultDisplayOptions <- DisplayOptions.init ()
+        DefaultDisplayOptions <- DisplayOptions.Create()
         DefaultTemplate <- ChartTemplates.plotly

--- a/tests/Plotly.NET.Tests.FSharpConsole/Program.fs
+++ b/tests/Plotly.NET.Tests.FSharpConsole/Program.fs
@@ -1,10 +1,12 @@
 // Learn more about F# at http://docs.microsoft.com/dotnet/fsharp
 
 open System
+open System.IO
 open Plotly.NET
 open Plotly.NET.LayoutObjects
 open Plotly.NET.TraceObjects
 open DynamicObj
+open Giraffe.ViewEngine
 
 // Define a function to construct a message to print
 let from whom =
@@ -19,8 +21,17 @@ let main argv =
         |> Chart.withAxisAnchor(Y=2)
     ]
     |> Chart.combine
-    //|> Chart.withYAxis(LinearAxis.init(),Id=StyleParam.SubPlotId.YAxis 1)
-    //|> Chart.withYAxis(LinearAxis.init(Shift = 10, Anchor = StyleParam.LinearAxisId.Free),Id=StyleParam.SubPlotId.YAxis 2)
+    |> Chart.withYAxis (LinearAxis.init(), Id = StyleParam.SubPlotId.YAxis 1)
+    |> Chart.withYAxis (LinearAxis.init(Anchor = StyleParam.LinearAxisId.Free, Shift = -50, ShowLine = true), Id = StyleParam.SubPlotId.YAxis 2)
+    |> Chart.withDescription [
+        h1 [] [str "now look at this!"]
+        ul [] [
+            li [] [str "this"]
+            li [] [str "is"]
+            li [] [str "a"]
+            li [] [img [_src "https://images.deepai.org/machine-learning-models/0c7ba850aa2443d7b40f9a45d9c86d3f/text2imgthumb.jpeg"]]
+        ]
+    ]
+    |> Chart.withSize(1000,1000)
     |> Chart.show
-    
     0

--- a/tests/Plotly.NET.Tests/HtmlCodegen/ChartLayout.fs
+++ b/tests/Plotly.NET.Tests/HtmlCodegen/ChartLayout.fs
@@ -5,6 +5,7 @@ open Plotly.NET
 open Plotly.NET.LayoutObjects
 open Plotly.NET.TraceObjects
 open Plotly.NET.GenericChart
+open Giraffe.ViewEngine
 
 open TestUtils.HtmlCodegen
 
@@ -307,34 +308,32 @@ let ``Shapes`` =
 let displayOptionsChartDescriptionChart =
     let x = [1.; 2.; 3.; 4.; 5.; 6.; 7.; 8.; 9.; 10.; ]
     let y = [2.; 1.5; 5.; 1.5; 3.; 2.5; 2.5; 1.5; 3.5; 1.]
-    let description1 = ChartDescription.create "Hello" "F#"
+    let description1 = [
+        h3 [] [str "Hello"]
+        p [] [str "F#"] 
+    ]
     Chart.Point(x,y,Name="desc1", UseDefaults = false)    
     |> Chart.withDescription(description1)
     
 let additionalHeadTagsChart =
     let x = [1.; 2.; 3.; 4.; 5.; 6.; 7.; 8.; 9.; 10.; ]
     let y = [2.; 1.5; 5.; 1.5; 3.; 2.5; 2.5; 1.5; 3.5; 1.]
-    let bulmaHero = """<section class="hero is-primary is-bold">
-    <div class="hero-body">
-      <p class="title">
-        Hero title
-      </p>
-      <p class="subtitle">
-        Hero subtitle
-      </p>
-    </div>
-    </section>
-    """
-    
+    let bulmaHero = 
+        section [_class"hero is-primary is-bold"] [
+            div [_class "hero-body"] [
+              p [_class "title"] [str "Hero title"]
+              p [_class "subtitle"] [str "Hero subtitle"]
+            ]
+        ]
     // chart description containing bulma classes
-    let description3 =
-      ChartDescription.create 
-          """<h1 class="title">I am heading</h1>""" 
-         bulmaHero
+    let description3 = [
+        h1 [_class "title"] [str "I am heading"]
+        bulmaHero
+    ]
     Chart.Point(x,y,Name="desc3", UseDefaults = false)    
     |> Chart.withDescription description3
     // Add reference to the bulma css framework
-    |> Chart.withAdditionalHeadTags ["""<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.2/css/bulma.min.css">"""]
+    |> Chart.withAdditionalHeadTags [link [_rel "stylesheet"; _href "https://cdn.jsdelivr.net/npm/bulma@0.9.2/css/bulma.min.css"]]
 
 let mathtexv3Chart =
     [
@@ -376,8 +375,8 @@ let ``Display options`` =
             |> substringIsInChart displayOptionsChartDescriptionChart toEmbeddedHTML
         );
         testCase "Additional head tags" ( fun () ->
-            [ "<h3><h1 class=\"title\">I am heading</h1></h3>"
-              "<p><section class=\"hero is-primary is-bold\">"
+            [ "<h1 class=\"title\">I am heading</h1>"
+              "<section class=\"hero is-primary is-bold\">"
               "<div class=\"hero-body\">"
               "<p class=\"title\">"
               "Hero title"

--- a/tests/Plotly.NET.Tests/HtmlCodegen/SimpleTests.fs
+++ b/tests/Plotly.NET.Tests/HtmlCodegen/SimpleTests.fs
@@ -19,9 +19,9 @@ let simpleChart =
 [<Tests>]
 let ``Html layout tests`` =
     testList "SimpleTests.Simple tests" [
-        testCase "Expecting plotly js" ( fun () ->
-            "https://cdn.plot.ly/plotly-2.17.1.min"
-            |> chartGeneratedContains simpleChart
+        testCase "Expecting plotly js script reference in generated html document" ( fun () ->
+            $"""https://cdn.plot.ly/plotly-{Globals.PLOTLYJS_VERSION}.min"""
+            |> substringIsInChart simpleChart toEmbeddedHTML 
         );
         testCase "Expecting data" ( fun () ->
             """var data = [{"type":"scatter","mode":"markers","x":[0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0],"y":[0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0],"marker":{},"line":{}}];"""
@@ -29,14 +29,6 @@ let ``Html layout tests`` =
         );
         testCase "Expecting layout info" (fun () ->
             """var layout = {"title":{"text":"Hello world!"},"xaxis":{"title":{"text":"xAxis"},"showgrid":false},"yaxis":{"title":{"text":"yAxis"},"showgrid":false}};"""
-            |> chartGeneratedContains simpleChart
-        );
-        testCase "Expecting cloudflare link" (fun () ->
-            "\"https://cdnjs.cloudflare.com/ajax/libs/require.js"
-            |> chartGeneratedContains simpleChart
-        );
-        testCase "Expecting require config" (fun () ->
-            "var fsharpPlotlyRequire = requirejs.config({context:'fsharp-plotly',paths:{plotly:'https://cdn.plot.ly/plotly-2.17.1.min'}}) || require;"
             |> chartGeneratedContains simpleChart
         );
         testCase "Expecting html tags in embedded page only" (fun () ->


### PR DESCRIPTION
This PR uses [Giraffe.ViewEngine](https://github.com/giraffe-fsharp/Giraffe.ViewEngine) as a statically typed html dsl. This has the obvious advantaged of no more misspelled html, as well as better structured html output.

closes #73