### PR TITLE
change Mabox to Mapbox in GenericChartExtensions, 2 uses in CSharpConsole tests, 2 RELEASE_NOTES.md

### DIFF
--- a/src/Plotly.NET.CSharp/GenericChartExtensions.cs
+++ b/src/Plotly.NET.CSharp/GenericChartExtensions.cs
@@ -298,7 +298,7 @@ namespace Plotly.NET.CSharp
         /// <param name="gChart">The chart in which to change the mapbox</param>
         /// <param name="mapbox">The Mapbox to set on the chart's layout</param>
         /// <param name="Id">The target mapbox id on which the Mapbox should be set. Default is 1.</param>
-        public static GenericChart.GenericChart WithMabox(
+        public static GenericChart.GenericChart WithMapbox(
             this GenericChart.GenericChart gChart,
             Mapbox mapbox, 
             Optional<int> Id = default
@@ -324,7 +324,7 @@ namespace Plotly.NET.CSharp
         /// <param name="Pitch">Sets the pitch angle of the map (in degrees, where "0" means perpendicular to the surface of the map) (mapbox.pitch).</param>
         /// <param name="Layers">Sets the layers of this Mapbox</param>
         /// <param name="Id">The target mapbox id</param>
-        public static GenericChart.GenericChart WithMaboxStyle(
+        public static GenericChart.GenericChart WithMapboxStyle(
             this GenericChart.GenericChart gChart,
             Optional<Domain> Domain = default, 
             Optional<string> AccessToken = default, 

--- a/src/Plotly.NET.CSharp/RELEASE_NOTES.md
+++ b/src/Plotly.NET.CSharp/RELEASE_NOTES.md
@@ -133,8 +133,8 @@ added C# bindings for statistical charts
 Optional arguments are now wrapped in a custom `Optional<T>` type to allow usage of both reference and value types for optional arguments across the whole API.
 
 Some GenericChart extension methods were also added:
-- WithMabox
-- WithMaboxStyle
+- WithMapbox
+- WithMapboxStyle
 
 ### 0.0.1 - June 15 2022
 

--- a/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
+++ b/tests/Plotly.NET.Tests.CSharpConsole/Program.cs
@@ -520,7 +520,7 @@ namespace TestConsoleApp
                                     Name: "bubblemapbox"
                                 ),
                             }
-                        ).WithMaboxStyle(
+                        ).WithMapboxStyle(
                             Style: MapboxStyle.OpenStreetMap,
                             Id: 38
                         ).WithTraceInfo(
@@ -531,7 +531,7 @@ namespace TestConsoleApp
                             longitudes: new int [] { 1,2,2,2,3,4,5,5 },
                             latitudes:  new int [] { 1,2,2,2,3,4,5,5 },
                             ShowScale: false
-                        ).WithMaboxStyle(
+                        ).WithMapboxStyle(
                             Style: MapboxStyle.OpenStreetMap,
                             Id: 39
                         ).WithTraceInfo(


### PR DESCRIPTION
Make c# consistent with the underlying plotly.NET, so change 
1. Mabox to Mapbox in GenericChartExtensions (2 places)
2. 2 uses in CSharpConsole tests
3. 2 lines in RELEASE_NOTES.md