### PR TITLE
LINQPad integration

### DIFF
--- a/src/Plotly.NET/ChartAPI/GenericChart.fs
+++ b/src/Plotly.NET/ChartAPI/GenericChart.fs
@@ -138,7 +138,7 @@ module rec GenericChart =
         | Chart of Trace * Layout * Config * DisplayOptions
         | MultiChart of Trace list * Layout * Config * DisplayOptions
         
-        member this.ToDump () =
+        member private this.ToDump () =
             let html = toEmbeddedHTML this
     
             let iFrameType = Type.GetType("LINQPad.Controls.IFrame, LINQPad.Runtime")

--- a/src/Plotly.NET/ChartAPI/GenericChart.fs
+++ b/src/Plotly.NET/ChartAPI/GenericChart.fs
@@ -140,13 +140,16 @@ module rec GenericChart =
         
         /// Method to support dumping charts in LINQPad.
         // See https://www.linqpad.net/CustomizingDump.aspx
-        member private this.ToDump () =
+        member private this.ToDump () : System.Object =
             let html = toEmbeddedHTML this
     
             let iFrameType = Type.GetType("LINQPad.Controls.IFrame, LINQPad.Runtime")
-            let iFrame = System.Activator.CreateInstance(iFrameType, html, true);
-    
-            iFrame
+            
+            if isNull iFrameType then
+                this
+            else
+                let iFrame = System.Activator.CreateInstance(iFrameType, html, true);
+                iFrame
 
     let toFigure (gChart: GenericChart) =
         match gChart with

--- a/src/Plotly.NET/ChartAPI/GenericChart.fs
+++ b/src/Plotly.NET/ChartAPI/GenericChart.fs
@@ -99,7 +99,7 @@ type HTML() =
 
 /// Module to represent a GenericChart
 [<Extension>]
-module GenericChart =
+module rec GenericChart =
 
     type Figure =
         {
@@ -228,9 +228,7 @@ module GenericChart =
     //         let l' = getLayouts gChart
     //         MultiChart (traces, Some (layouts@l'))
 
-    open Plotly.NET.LayoutObjects
     // Combines two GenericChart
-
     let combine (gCharts: seq<GenericChart>) =
         // temporary hard fix for some props, see https://github.com/CSBiology/DynamicObj/issues/11
 

--- a/src/Plotly.NET/ChartAPI/GenericChart.fs
+++ b/src/Plotly.NET/ChartAPI/GenericChart.fs
@@ -138,6 +138,8 @@ module rec GenericChart =
         | Chart of Trace * Layout * Config * DisplayOptions
         | MultiChart of Trace list * Layout * Config * DisplayOptions
         
+        /// Method to support dumping charts in LINQPad.
+        // See https://www.linqpad.net/CustomizingDump.aspx
         member private this.ToDump () =
             let html = toEmbeddedHTML this
     

--- a/src/Plotly.NET/ChartAPI/GenericChart.fs
+++ b/src/Plotly.NET/ChartAPI/GenericChart.fs
@@ -139,9 +139,7 @@ module rec GenericChart =
         | MultiChart of Trace list * Layout * Config * DisplayOptions
         
         member this.ToDump () =
-            //let temp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{Guid.NewGuid()}.html")
-            
-            let html = System.IO.File.ReadAllText "d:\\temp\\chart.html"
+            let html = toEmbeddedHTML this
     
             let iFrameType = Type.GetType("LINQPad.Controls.IFrame, LINQPad.Runtime")
             let iFrame = System.Activator.CreateInstance(iFrameType, html, true);

--- a/src/Plotly.NET/ChartAPI/GenericChart.fs
+++ b/src/Plotly.NET/ChartAPI/GenericChart.fs
@@ -137,6 +137,16 @@ module GenericChart =
     type GenericChart =
         | Chart of Trace * Layout * Config * DisplayOptions
         | MultiChart of Trace list * Layout * Config * DisplayOptions
+        
+        member this.ToDump () =
+            //let temp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{Guid.NewGuid()}.html")
+            
+            let html = System.IO.File.ReadAllText "d:\\temp\\chart.html"
+    
+            let iFrameType = Type.GetType("LINQPad.Controls.IFrame, LINQPad.Runtime")
+            let iFrame = System.Activator.CreateInstance(iFrameType, html, true);
+    
+            iFrame
 
     let toFigure (gChart: GenericChart) =
         match gChart with


### PR DESCRIPTION
Hello,

at first I must declare, that this is my first F# pull request, so please let me ask for some patience :-)

### Motivation
I am a big fan of [LINQPad](https://www.linqpad.net/) as a (C# and F#) code scratchpad. One of it's main features is the `.Dump()` extension method, which let's you bring almost everything into a nicely formatted output.

Almost everything: Plotly.Net charts are dumped as plain objects:

<img src="https://github.com/plotly/Plotly.NET/assets/6525889/6dcab4df-ba7e-42bc-b5a0-4ad1f12f4fa2" alt="image" width="600"/>

This is a pity, since LINQPad's output is html and it would perfectly support interactive charts.

### How To
LINQPad [supports customized dumps from F#](https://forum.linqpad.net/discussion/1395/bug-cant-hook-up-todump-extension-method-with-f-program) in two ways:
* As a static method is My Extensions. Then it executes for all types.
* As an instance method on the type itself being dumped.

The first option would require every user to implement an extension, so the second is the way to go.



### Implementation
After some try-and-error, I figured out a way to support Plotly.Net in LINQPad with relatively view changes.

* Add a `.ToDump()` method to GenericChart  
  This method can be (and is) private.
* Make GenericChart a recirsive module  
  `ToDump` must be able to call `toEmbeddedHTML`, which is defined later within this module.  
  Maybe there is a better solution to this.
* Within `ToDump`, an instance of `LINQPad.Controls.IFrame` is created using reflection and returned.  
  The use of reflection avoids a static reference to `LINQPad.Runtime`

### The Result
![image](https://github.com/plotly/Plotly.NET/assets/6525889/7284f60b-6da7-4cfb-a6b7-92780d6f1740)


  