### PR TITLE
Fixed typos with decreasing

### DIFF
--- a/docs/finance-charts/candlestick.fsx
+++ b/docs/finance-charts/candlestick.fsx
@@ -87,7 +87,7 @@ candles1 |> GenericChart.toChartHTML
 (***include-it-raw***)
 
 (**
-## Changing the increasing/decresing colors
+## Changing the increasing/decreasing colors
 *)
 
 let candles2 =

--- a/docs/finance-charts/ohlc.fsx
+++ b/docs/finance-charts/ohlc.fsx
@@ -81,7 +81,7 @@ ohlc1 |> GenericChart.toChartHTML
 (***include-it-raw***)
 
 (**
-## Changing the increasing/decresing colors
+## Changing the increasing/decreasing colors
 *)
 
 let ohlc2 =


### PR DESCRIPTION
I noticed a typo on your documentation for Candlestick charts where "decreasing" was spelled "decresing" as shown here:
<img width="403" alt="image" src="https://github.com/plotly/Plotly.NET/assets/5049957/13efe00f-170d-4b0c-899d-e6d7accdacf1">

On searching, I found this present on one other page as well. This PR fixes the tpyo.