### PR TITLE
Fix pattern shape mix-up between ascending and descending

### DIFF
--- a/src/Plotly.NET/CommonAbstractions/StyleParams.fs
+++ b/src/Plotly.NET/CommonAbstractions/StyleParams.fs
@@ -2533,8 +2533,8 @@ module StyleParam =
         static member toString =
             function
             | None -> ""
-            | DiagonalDescending -> "/"
-            | DiagonalAscending -> """\"""
+            | DiagonalDescending -> """\"""
+            | DiagonalAscending ->  "/"
             | DiagonalChecked -> "x"
             | HorizontalLines -> "-"
             | VerticalLines -> "|"


### PR DESCRIPTION
closes #474

The introduced change switches the characters that define the pattern fill shape:

Ascending stripes: "\\" -> "/"
Descending stripes: "/" -> "\\"